### PR TITLE
Fix native webview bind callback ABI for 10_bind

### DIFF
--- a/examples/10_bind/main.mbt
+++ b/examples/10_bind/main.mbt
@@ -46,7 +46,7 @@ let html =
   #|   </head>
   #|   <body>
   #|     <h1>Hello, Moonbit!</h1>
-  #|     <button onclick="press('I was pressed!', 123, new Date().toISOString()).then(log).catch(logError);">
+  #|     <button onclick="window.press('I was pressed!', 123, new Date().toISOString()).then(log).catch(logError);">
   #|        Press me!
   #|     </button>
   #|     <pre id="output">Click the button to call MoonBit.</pre>

--- a/src/binding.mbt
+++ b/src/binding.mbt
@@ -88,7 +88,9 @@ pub extern "C" fn webview_init(webview : Webview_t, js : Bytes) -> Int = "webvie
 pub extern "C" fn webview_eval(webview : Webview_t, js : Bytes) -> Int = "webview_eval"
 
 ///|
-/// extern void webview_bind(webview_t w, const char *name, void (*fn)(const char *id, const char *req, void *arg), void *arg);
+/// Wrapper around `webview_bind` that stores the owned MoonBit closure inside
+/// an opaque native binding record and returns that record as a handle for
+/// later unbind/cleanup.
 #borrow(name)
 #owned(closure)
 pub extern "C" fn webview_bind(
@@ -108,7 +110,8 @@ extern "C" fn webview_copy_cstr(cstr : CStr) -> Bytes = "moonbit_webview_copy_cs
 extern "C" fn webview_binding_is_null(binding : BindingHandle) -> Bool = "moonbit_is_null"
 
 ///|
-/// extern void webview_unbind(webview_t w, const char *name);
+/// Wrapper around `webview_unbind` that also releases the opaque native
+/// binding handle returned by `webview_bind`.
 #borrow(name)
 pub extern "C" fn webview_unbind(
   webview : Webview_t,

--- a/src/binding.mbt
+++ b/src/binding.mbt
@@ -80,17 +80,27 @@ pub extern "C" fn webview_eval(webview : Webview_t, js : Bytes) -> Int = "webvie
 ///|
 /// extern void webview_bind(webview_t w, const char *name, void (*fn)(const char *id, const char *req, void *arg), void *arg);
 #borrow(name)
+#owned(closure)
 pub extern "C" fn webview_bind(
   webview : Webview_t,
   name : Bytes,
-  call_closure : FuncRef[(Bytes, Bytes, (Bytes, Bytes) -> Unit) -> Unit],
+  call_closure : FuncRef[(Int64, Int64, (Bytes, Bytes) -> Unit) -> Unit],
   closure : (Bytes, Bytes) -> Unit,
-) -> Int = "webview_bind"
+) -> Int64 = "moonbit_webview_bind"
+
+///|
+/// Copies a raw C string into MoonBit-managed bytes, preserving the trailing
+/// null terminator.
+extern "C" fn webview_copy_cstr(cstr : Int64) -> Bytes = "moonbit_webview_copy_cstr"
 
 ///|
 /// extern void webview_unbind(webview_t w, const char *name);
 #borrow(name)
-pub extern "C" fn webview_unbind(webview : Webview_t, name : Bytes) -> Int = "webview_unbind"
+pub extern "C" fn webview_unbind(
+  webview : Webview_t,
+  name : Bytes,
+  binding : Int64,
+) -> Int = "moonbit_webview_unbind"
 
 ///|
 /// extern void webview_return(webview_t w, const char *seq, int status, const char *result);

--- a/src/binding.mbt
+++ b/src/binding.mbt
@@ -9,6 +9,16 @@
 pub type Webview_t
 
 ///|
+/// Opaque C string pointer received from the native webview callback.
+#external
+pub type CStr
+
+///|
+/// Opaque binding handle returned by the native webview wrapper.
+#external
+pub type BindingHandle
+
+///|
 /// extern webview_t webview_create(int debug, void *window);
 pub extern "C" fn webview_create(debug : Int, window : Int64) -> Webview_t = "webview_create"
 
@@ -84,14 +94,18 @@ pub extern "C" fn webview_eval(webview : Webview_t, js : Bytes) -> Int = "webvie
 pub extern "C" fn webview_bind(
   webview : Webview_t,
   name : Bytes,
-  call_closure : FuncRef[(Int64, Int64, (Bytes, Bytes) -> Unit) -> Unit],
+  call_closure : FuncRef[(CStr, CStr, (Bytes, Bytes) -> Unit) -> Unit],
   closure : (Bytes, Bytes) -> Unit,
-) -> Int64 = "moonbit_webview_bind"
+) -> BindingHandle = "moonbit_webview_bind"
 
 ///|
 /// Copies a raw C string into MoonBit-managed bytes, preserving the trailing
 /// null terminator.
-extern "C" fn webview_copy_cstr(cstr : Int64) -> Bytes = "moonbit_webview_copy_cstr"
+extern "C" fn webview_copy_cstr(cstr : CStr) -> Bytes = "moonbit_webview_copy_cstr"
+
+///|
+/// Checks whether a native binding handle is null.
+extern "C" fn webview_binding_is_null(binding : BindingHandle) -> Bool = "moonbit_is_null"
 
 ///|
 /// extern void webview_unbind(webview_t w, const char *name);
@@ -99,7 +113,7 @@ extern "C" fn webview_copy_cstr(cstr : Int64) -> Bytes = "moonbit_webview_copy_c
 pub extern "C" fn webview_unbind(
   webview : Webview_t,
   name : Bytes,
-  binding : Int64,
+  binding : BindingHandle,
 ) -> Int = "moonbit_webview_unbind"
 
 ///|

--- a/src/moon.pkg
+++ b/src/moon.pkg
@@ -9,6 +9,7 @@ options(
       "cc-link-flags": "-Llib -lwebview",
     },
   },
+  "native-stub": [ "stub.c" ],
   "supported-targets": [ "native" ],
   targets: { "binding.mbt": [ "native" ], "webview.mbt": [ "native" ] },
 )

--- a/src/pkg.generated.mbti
+++ b/src/pkg.generated.mbti
@@ -2,7 +2,7 @@
 package "justjavac/webview"
 
 // Values
-pub fn webview_bind(Webview_t, Bytes, FuncRef[(Bytes, Bytes, (Bytes, Bytes) -> Unit) -> Unit], (Bytes, Bytes) -> Unit) -> Int
+pub fn webview_bind(Webview_t, Bytes, FuncRef[(Int64, Int64, (Bytes, Bytes) -> Unit) -> Unit], (Bytes, Bytes) -> Unit) -> Int64
 
 pub fn webview_create(Int, Int64) -> Webview_t
 
@@ -32,7 +32,7 @@ pub fn webview_set_title(Webview_t, Bytes) -> Int
 
 pub fn webview_terminate(Webview_t) -> Int
 
-pub fn webview_unbind(Webview_t, Bytes) -> Int
+pub fn webview_unbind(Webview_t, Bytes, Int64) -> Int
 
 // Errors
 
@@ -77,4 +77,3 @@ pub type Webview_t
 // Type aliases
 
 // Traits
-

--- a/src/pkg.generated.mbti
+++ b/src/pkg.generated.mbti
@@ -2,7 +2,7 @@
 package "justjavac/webview"
 
 // Values
-pub fn webview_bind(Webview_t, Bytes, FuncRef[(Int64, Int64, (Bytes, Bytes) -> Unit) -> Unit], (Bytes, Bytes) -> Unit) -> Int64
+pub fn webview_bind(Webview_t, Bytes, FuncRef[(CStr, CStr, (Bytes, Bytes) -> Unit) -> Unit], (Bytes, Bytes) -> Unit) -> BindingHandle
 
 pub fn webview_create(Int, Int64) -> Webview_t
 
@@ -32,11 +32,17 @@ pub fn webview_set_title(Webview_t, Bytes) -> Int
 
 pub fn webview_terminate(Webview_t) -> Int
 
-pub fn webview_unbind(Webview_t, Bytes, Int64) -> Int
+pub fn webview_unbind(Webview_t, Bytes, BindingHandle) -> Int
 
 // Errors
 
 // Types and methods
+#external
+pub type BindingHandle
+
+#external
+pub type CStr
+
 pub(all) enum NativeHandleKind {
   Window
   Widget
@@ -77,3 +83,4 @@ pub type Webview_t
 // Type aliases
 
 // Traits
+

--- a/src/stub.c
+++ b/src/stub.c
@@ -1,79 +1,91 @@
-#include "webview/webview.h"
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
 
-webview_t moonbit_webview_create(int debug, void *window) {
-  return webview_create(debug, window);
+#include "moonbit.h"
+
+typedef void *webview_t;
+
+typedef void (*moonbit_webview_bind_callback_t)(int64_t seq, int64_t req, void *arg);
+
+struct moonbit_webview_binding {
+  moonbit_webview_bind_callback_t callback;
+  void *arg;
+};
+
+int webview_bind(
+  webview_t w,
+  const char *name,
+  void (*fn)(const char *seq, const char *req, void *arg),
+  void *arg
+);
+int webview_unbind(webview_t w, const char *name);
+
+static void moonbit_webview_free_binding(struct moonbit_webview_binding *binding) {
+  if (binding == NULL) {
+    return;
+  }
+  if (binding->arg != NULL) {
+    moonbit_decref(binding->arg);
+  }
+  free(binding);
 }
 
-void moonbit_webview_destroy(webview_t w) {
-  webview_destroy(w);
+static void moonbit_webview_bind_trampoline(
+  const char *seq,
+  const char *req,
+  void *arg
+) {
+  struct moonbit_webview_binding *binding = arg;
+  binding->callback((int64_t)(intptr_t)seq, (int64_t)(intptr_t)req, binding->arg);
 }
 
-// void webview_run(webview_t w);
-void moonbit_webview_run(webview_t w) {
-  webview_run(w);
+int64_t moonbit_webview_bind(
+  webview_t w,
+  const char *name,
+  moonbit_webview_bind_callback_t fn,
+  void *arg
+) {
+  struct moonbit_webview_binding *binding =
+    (struct moonbit_webview_binding *)malloc(sizeof(struct moonbit_webview_binding));
+  int result;
+
+  if (binding == NULL) {
+    return 0;
+  }
+
+  binding->callback = fn;
+  binding->arg = arg;
+  result = webview_bind(w, name, moonbit_webview_bind_trampoline, binding);
+  if (result != 0) {
+    moonbit_webview_free_binding(binding);
+    return 0;
+  }
+
+  return (int64_t)(intptr_t)binding;
 }
 
-// void webview_terminate(webview_t w);
-void moonbit_webview_terminate(webview_t w) {
-  webview_terminate(w);
+int moonbit_webview_unbind(webview_t w, const char *name, int64_t raw_binding) {
+  struct moonbit_webview_binding *binding =
+    (struct moonbit_webview_binding *)(intptr_t)raw_binding;
+  int result = webview_unbind(w, name);
+  moonbit_webview_free_binding(binding);
+  return result;
 }
 
-// void webview_dispatch(webview_t w, void (*fn)(webview_t w, void *arg), void *arg);
-void moonbit_webview_dispatch(webview_t w, void (*fn)(webview_t w, void *arg), void *arg) {
-  webview_dispatch(w, fn, arg);
-}
+moonbit_bytes_t moonbit_webview_copy_cstr(int64_t raw_cstr) {
+  const char *cstr = (const char *)(intptr_t)raw_cstr;
+  moonbit_bytes_t bytes;
+  size_t len;
 
-// void *webview_get_window(webview_t w);
-void *moonbit_webview_get_window(webview_t w) {
-  return webview_get_window(w);
-}
+  if (cstr == NULL) {
+    bytes = moonbit_make_bytes_raw(1);
+    bytes[0] = '\0';
+    return bytes;
+  }
 
-// void *webview_get_native_handle(webview_t w, webview_native_handle_kind_t kind);
-void *moonbit_webview_get_native_handle(webview_t w, webview_native_handle_kind_t kind) {
-  return webview_get_native_handle(w, kind);
-}
-
-// void webview_set_title(webview_t w, const char *title);
-void moonbit_webview_set_title(webview_t w, const char *title) {
-  webview_set_title(w, title);
-}
-
-// void webview_set_size(webview_t w, int width, int height, webview_hint_t hints);
-void moonbit_webview_set_size(webview_t w, int width, int height, webview_hint_t hints) {
-  webview_set_size(w, width, height, hints);
-}
-
-// void webview_navigate(webview_t w, const char *url);
-void moonbit_webview_navigate(webview_t w, const char *url) {
-  webview_navigate(w, url);
-}
-
-// void webview_set_html(webview_t w, const char *html);
-void moonbit_webview_set_html(webview_t w, const char *html) {
-  webview_set_html(w, html);
-}
-
-// void webview_init(webview_t w, const char *js);
-void moonbit_webview_init(webview_t w, const char *js) {
-  webview_init(w, js);
-}
-
-// void webview_eval(webview_t w, const char *js);
-void moonbit_webview_eval(webview_t w, const char *js) {
-  webview_eval(w, js);
-}
-
-// void webview_bind(webview_t w, const char *name, void (*fn)(const char *seq, const char *req, void *arg), void *arg);
-void moonbit_webview_bind(webview_t w, const char *name, void (*fn)(const char *seq, const char *req, void *arg), void *arg) {
-  webview_bind(w, name, fn, arg);
-}
-
-// void webview_unbind(webview_t w, const char *name);
-void moonbit_webview_unbind(webview_t w, const char *name) {
-  webview_unbind(w, name);
-}
-
-// void webview_return(webview_t w, const char *seq, int status, const char *result);
-void moonbit_webview_return(webview_t w, const char *seq, int status, const char *result) {
-  webview_return(w, seq, status, result);
+  len = strlen(cstr) + 1;
+  bytes = moonbit_make_bytes_raw((int32_t)len);
+  memcpy(bytes, cstr, len);
+  return bytes;
 }

--- a/src/stub.c
+++ b/src/stub.c
@@ -1,4 +1,5 @@
 #include <stdint.h>
+#include <limits.h>
 #include <stdlib.h>
 #include <string.h>
 
@@ -51,6 +52,9 @@ void *moonbit_webview_bind(
   int result;
 
   if (binding == NULL) {
+    if (arg != NULL) {
+      moonbit_decref(arg);
+    }
     return NULL;
   }
 
@@ -84,6 +88,9 @@ moonbit_bytes_t moonbit_webview_copy_cstr(void *raw_cstr) {
   }
 
   len = strlen(cstr) + 1;
+  if (len > INT32_MAX) {
+    abort();
+  }
   bytes = moonbit_make_bytes_raw((int32_t)len);
   memcpy(bytes, cstr, len);
   return bytes;

--- a/src/stub.c
+++ b/src/stub.c
@@ -6,7 +6,7 @@
 
 typedef void *webview_t;
 
-typedef void (*moonbit_webview_bind_callback_t)(int64_t seq, int64_t req, void *arg);
+typedef void (*moonbit_webview_bind_callback_t)(void *seq, void *req, void *arg);
 
 struct moonbit_webview_binding {
   moonbit_webview_bind_callback_t callback;
@@ -37,10 +37,10 @@ static void moonbit_webview_bind_trampoline(
   void *arg
 ) {
   struct moonbit_webview_binding *binding = arg;
-  binding->callback((int64_t)(intptr_t)seq, (int64_t)(intptr_t)req, binding->arg);
+  binding->callback((void *)seq, (void *)req, binding->arg);
 }
 
-int64_t moonbit_webview_bind(
+void *moonbit_webview_bind(
   webview_t w,
   const char *name,
   moonbit_webview_bind_callback_t fn,
@@ -51,7 +51,7 @@ int64_t moonbit_webview_bind(
   int result;
 
   if (binding == NULL) {
-    return 0;
+    return NULL;
   }
 
   binding->callback = fn;
@@ -59,22 +59,21 @@ int64_t moonbit_webview_bind(
   result = webview_bind(w, name, moonbit_webview_bind_trampoline, binding);
   if (result != 0) {
     moonbit_webview_free_binding(binding);
-    return 0;
+    return NULL;
   }
 
-  return (int64_t)(intptr_t)binding;
+  return binding;
 }
 
-int moonbit_webview_unbind(webview_t w, const char *name, int64_t raw_binding) {
-  struct moonbit_webview_binding *binding =
-    (struct moonbit_webview_binding *)(intptr_t)raw_binding;
+int moonbit_webview_unbind(webview_t w, const char *name, void *raw_binding) {
+  struct moonbit_webview_binding *binding = raw_binding;
   int result = webview_unbind(w, name);
   moonbit_webview_free_binding(binding);
   return result;
 }
 
-moonbit_bytes_t moonbit_webview_copy_cstr(int64_t raw_cstr) {
-  const char *cstr = (const char *)(intptr_t)raw_cstr;
+moonbit_bytes_t moonbit_webview_copy_cstr(void *raw_cstr) {
+  const char *cstr = raw_cstr;
   moonbit_bytes_t bytes;
   size_t len;
 

--- a/src/webview.mbt
+++ b/src/webview.mbt
@@ -38,7 +38,7 @@ pub(all) enum SizeHint {
 /// ```
 struct Webview {
   handle : Webview_t
-  bindings : Map[String, Int64]
+  bindings : Map[String, BindingHandle]
 }
 
 ///|
@@ -113,7 +113,7 @@ pub fn Webview::bind(
     },
     callback,
   )
-  if binding != 0 {
+  if !webview_binding_is_null(binding) {
     self.bindings.set(name, binding)
   }
 }

--- a/src/webview.mbt
+++ b/src/webview.mbt
@@ -38,7 +38,7 @@ pub(all) enum SizeHint {
 /// ```
 struct Webview {
   handle : Webview_t
-  callbacks : Map[String, (Bytes, Bytes) -> Unit]
+  bindings : Map[String, Int64]
 }
 
 ///|
@@ -48,10 +48,7 @@ struct Webview {
 /// - `debug` - If set to 1, enables debugging mode which provides additional logging.
 pub fn Webview::new(debug? : Int = 0) -> Webview {
   let window : Int64 = 0
-  let webview = Webview::{
-    handle: webview_create(debug, window),
-    callbacks: {},
-  }
+  let webview = Webview::{ handle: webview_create(debug, window), bindings: {} }
   webview
 }
 
@@ -59,10 +56,9 @@ pub fn Webview::new(debug? : Int = 0) -> Webview {
 /// Destroys the webview and closes the window. It is safe to call this
 /// function from another background thread.
 pub fn Webview::destroy(self : Webview) -> Unit {
-  for name, _callback in self.callbacks {
-    let _ = self.unbind(name)
+  for name, binding in self.bindings {
+    let _ = webview_unbind(self.handle, @ffi.to_cstr(name), binding)
   }
-  let _ = webview_terminate(self.handle)
   let _ = webview_destroy(self.handle)
 }
 
@@ -107,13 +103,19 @@ pub fn Webview::bind(
   name : String,
   callback : (Bytes, Bytes) -> Unit,
 ) -> Unit {
-  self.callbacks.set(name, callback)
-  let _ = webview_bind(
+  let binding = webview_bind(
     self.handle,
     @ffi.to_cstr(name),
-    fn(id, req, f) { f(id, req) },
+    fn(raw_id, raw_req, f) {
+      let id = webview_copy_cstr(raw_id)
+      let req = webview_copy_cstr(raw_req)
+      f(id, req)
+    },
     callback,
   )
+  if binding != 0 {
+    self.bindings.set(name, binding)
+  }
 }
 
 ///|
@@ -125,8 +127,13 @@ pub fn Webview::bind(
 /// Returns:
 /// - `WEBVIEW_ERROR_NOT_FOUND` - No binding exists with the specified name.
 pub fn Webview::unbind(self : Webview, name : String) -> Unit {
-  self.callbacks.remove(name)
-  let _ = webview_unbind(self.handle, @ffi.to_cstr(name))
+  match self.bindings.get(name) {
+    Some(binding) => {
+      self.bindings.remove(name)
+      let _ = webview_unbind(self.handle, @ffi.to_cstr(name), binding)
+    }
+    None => ()
+  }
 }
 
 ///|

--- a/test/moon.mod.json
+++ b/test/moon.mod.json
@@ -2,6 +2,7 @@
   "name": "justjavac/webview/test",
   "version": "0.1.0",
   "deps": {
+    "justjavac/ffi": "0.1.12",
     "justjavac/webview": {
       "path": ".."
     }

--- a/test/moon.pkg
+++ b/test/moon.pkg
@@ -1,4 +1,5 @@
 import {
+  "justjavac/ffi",
   "justjavac/webview",
 }
 

--- a/test/webview_test.mbt
+++ b/test/webview_test.mbt
@@ -17,5 +17,38 @@ test "Create a window, run app and terminate it" {
   webview.dispatch(fn() {  })
   webview.dispatch(fn() { webview.terminate() })
   webview.run()
-  webview.destroy()
+}
+
+///|
+test "Bind callback marshals C strings safely" {
+  let mut called = false
+  let mut callback_id = ""
+  let mut callback_req = ""
+  let webview = @webview.Webview::new()
+  webview.bind("press", fn(id, req) {
+    callback_id = @ffi.from_cstr(id)
+    callback_req = @ffi.from_cstr(req)
+    called = true
+    webview.response(callback_id, 0, "{\"ok\":true}")
+    webview.terminate()
+  })
+  webview.set_html(
+    (
+      #| <html>
+      #|   <body>
+      #|     <script>
+      #|       window.onload = () => {
+      #|         window.press("hello", 123).catch((error) => {
+      #|           document.body.textContent = String(error);
+      #|         });
+      #|       };
+      #|     </script>
+      #|   </body>
+      #| </html>,
+    ),
+  )
+  webview.run()
+  assert_true(called)
+  assert_true(!callback_id.is_empty())
+  assert_eq(callback_req, "[\"hello\",123]")
 }


### PR DESCRIPTION
## Summary
- fix the `examples/10_bind` crash caused by declaring `libwebview` bind callback arguments as MoonBit `Bytes` instead of raw C pointers
- marshal callback `seq`/`req` into MoonBit-managed bytes before invoking user callbacks
- make closure ownership explicit with `#owned(closure)` and simplify the native wrapper around opaque binding handles
- replace the temporary `Int64` pointer plumbing with `#external type` values (`CStr`, `BindingHandle`) so raw native pointers stay opaque in MoonBit code
- update the example to call `window.press(...)` and add a native smoke test that auto-invokes the binding on load

## Root Cause
`libwebview` invokes bind callbacks with raw `const char *seq` / `const char *req` values. Our old FFI signature modeled those callback arguments as MoonBit `Bytes`, so the generated native code treated plain C pointers like MoonBit heap objects and attempted to refcount them. That is why `10_bind` crashed under ASan in `moonbit_incref_inlined` when the JS binding fired.

## What Changed
- changed the low-level bind callback ABI to accept raw foreign pointers and copy them into MoonBit-managed `Bytes` before user code runs
- kept ownership rules explicit: the binding name is borrowed and the stored closure is owned
- simplified the native stub by returning an opaque binding handle from `bind` and freeing the owned closure on `unbind`
- replaced the stopgap `Int64` pointer representation with `#external type` so these values are modeled as opaque foreign pointers instead of numbers

## Validation
- `moon check --target native`
- `moon fmt --check`
- `moon -C examples build 10_bind --target native`
- `moon -C examples fmt --check 10_bind`
- `moon --manifest-path test/moon.mod.json fmt --check`
- `DYLD_LIBRARY_PATH="/Users/cgqaq/code/moonbit-webview/lib" moon --manifest-path test/moon.mod.json test --target native`
- `moon -C examples run 10_bind --target native` manual tests