### PR TITLE
Add two-way MoonBit <-> JavaScript command bridge with CommandResponse replies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,8 +52,8 @@ jobs:
       - name: Run moon test (windows)
         if: ${{ matrix.os == 'windows-latest' }}
         env:
-          _CL_: /link /LIBPATH:lib webview.lib /DEBUG
-          PATH: lib;${{ env.PATH }}
+          _CL_: /link /LIBPATH:${{ github.workspace }}\lib webview.lib /DEBUG
+          PATH: ${{ github.workspace }}\lib;${{ env.PATH }}
         run: |
           moon -C test test --target native
 
@@ -67,8 +67,8 @@ jobs:
       - name: moon test --doc (windows)
         if: ${{ matrix.os == 'windows-latest' }}
         env:
-          _CL_: /link /LIBPATH:lib webview.lib /DEBUG
-          PATH: lib;${{ env.PATH }}
+          _CL_: /link /LIBPATH:${{ github.workspace }}\lib webview.lib /DEBUG
+          PATH: ${{ github.workspace }}\lib;${{ env.PATH }}
         run: |
           moon test --target native --doc
 
@@ -145,8 +145,8 @@ jobs:
       - name: Run moon test (windows)
         if: ${{ matrix.os == 'windows-latest' }}
         env:
-          _CL_: /link /LIBPATH:lib webview.lib /DEBUG
-          PATH: lib;${{ env.PATH }}
+          _CL_: /link /LIBPATH:${{ github.workspace }}\lib webview.lib /DEBUG
+          PATH: ${{ github.workspace }}\lib;${{ env.PATH }}
         run: |
           moon -C test test --target native
 
@@ -160,8 +160,8 @@ jobs:
       - name: moon test --doc (windows)
         if: ${{ matrix.os == 'windows-latest' }}
         env:
-          _CL_: /link /LIBPATH:lib webview.lib /DEBUG
-          PATH: lib;${{ env.PATH }}
+          _CL_: /link /LIBPATH:${{ github.workspace }}\lib webview.lib /DEBUG
+          PATH: ${{ github.workspace }}\lib;${{ env.PATH }}
         run: |
           moon test --target native --doc
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,14 +55,14 @@ jobs:
           _CL_: /link /LIBPATH:lib webview.lib /DEBUG
           PATH: lib;${{ env.PATH }}
         run: |
-          moon --manifest-path test/moon.mod.json test --target native
+          moon -C test test --target native
 
       # - name: Run moon test (non-windows)
       #   if: ${{ matrix.os != 'windows-latest' }}
       #   env:
       #     DYLD_LIBRARY_PATH: lib
       #   run: |
-      #     moon --manifest-path test/moon.mod.json test --target native
+      #     moon -C test test --target native
 
       - name: moon test --doc (windows)
         if: ${{ matrix.os == 'windows-latest' }}
@@ -148,14 +148,14 @@ jobs:
           _CL_: /link /LIBPATH:lib webview.lib /DEBUG
           PATH: lib;${{ env.PATH }}
         run: |
-          moon --manifest-path test/moon.mod.json test --target native
+          moon -C test test --target native
 
       # - name: Run moon test (non-windows)
       #   if: ${{ matrix.os != 'windows-latest' }}
       #   env:
       #     DYLD_LIBRARY_PATH: lib
       #   run: |
-      #     moon --manifest-path test/moon.mod.json test --target native
+      #     moon -C test test --target native
 
       - name: moon test --doc (windows)
         if: ${{ matrix.os == 'windows-latest' }}

--- a/README.md
+++ b/README.md
@@ -113,6 +113,55 @@ fn main {
 }
 ```
 
+## Command Bridge
+
+For structured JS <-> MoonBit communication, use `CommandBridge` on top of the
+existing low-level bindings.
+
+- JS -> MoonBit: `window.MoonBitBridge.send(name, payload)`
+- MoonBit -> JS: `bridge.send(name, payload)` and
+  `window.MoonBitBridge.onCommand(listener)`
+
+```moonbit
+struct SumPayload {
+  left : Int
+  right : Int
+} derive(ToJson, FromJson)
+
+struct SumReply {
+  total : Int
+} derive(ToJson, FromJson)
+
+struct NoticePayload {
+  message : String
+} derive(ToJson, FromJson)
+
+fn main {
+  let webview = @webview.Webview::new(debug=1)
+  let bridge = @webview.CommandBridge::new(webview)
+  bridge.handle("sum", fn(payload : SumPayload) {
+    let reply = SumReply::{ total: payload.left + payload.right }
+    bridge.send("notice", NoticePayload::{
+      message: "MoonBit computed " + reply.total.to_string(),
+    })
+    reply
+  })
+  webview.set_html(
+    #| <script>
+    #|   window.MoonBitBridge.onCommand((command) => {
+    #|     if (command.name === "notice") {
+    #|       console.log("MoonBit -> JS", command.payload);
+    #|     }
+    #|   });
+    #|   window.MoonBitBridge
+    #|     .send("sum", { left: 1, right: 2 })
+    #|     .then(console.log);
+    #| </script>,
+  )
+  webview.run()
+}
+```
+
 ## 📚 Examples
 
 This repository includes several examples in the `examples/` directory:
@@ -132,6 +181,7 @@ This repository includes several examples in the `examples/` directory:
 - **13_todo** - Complete todo application
 - **14_beforeunload** - Handling window close events
 - **15_close** - Window close management
+- **16_command** - Structured JS <-> MoonBit command bridge
 
 Run any example:
 

--- a/README.md
+++ b/README.md
@@ -134,6 +134,10 @@ Notes:
   page; it does not wait for a JavaScript reply.
 - MoonBit -> JS delivery is scheduled onto the webview event loop internally,
   so `bridge.send(...)` is safe to call off the UI thread.
+- `binding_name` must be unique per `Webview`. `CommandBridge::new(...)`
+  aborts immediately if that internal binding name is already in use.
+- Call `bridge.destroy()` if you want to unregister the bridge binding and
+  reuse the same `binding_name` on the same `Webview`.
 - If you want raw JSON handling on the MoonBit side, register the handler with
   `Json` as the payload type.
 

--- a/README.md
+++ b/README.md
@@ -122,6 +122,21 @@ existing low-level bindings.
 - MoonBit -> JS: `bridge.send(name, payload)` and
   `window.MoonBitBridge.onCommand(listener)`
 
+Notes:
+- `window.MoonBitBridge.send(...)` is request/reply. It returns a
+  `Promise<CommandResponse>`.
+- `CommandResponse.status` is `"ok"` or `"error"`.
+- On success, `CommandResponse.payload` contains the handler result.
+- On failure, `CommandResponse.error` contains the error message.
+- Use `bridge.handle_result(...)` if a MoonBit handler should explicitly return
+  `Result[Reply, String]` instead of always succeeding.
+- `bridge.send(...)` is fire-and-forget. It pushes a `Command` event into the
+  page; it does not wait for a JavaScript reply.
+- MoonBit -> JS delivery is scheduled onto the webview event loop internally,
+  so `bridge.send(...)` is safe to call off the UI thread.
+- If you want raw JSON handling on the MoonBit side, register the handler with
+  `Json` as the payload type.
+
 ```moonbit
 struct SumPayload {
   left : Int
@@ -139,10 +154,15 @@ struct NoticePayload {
 fn main {
   let webview = @webview.Webview::new(debug=1)
   let bridge = @webview.CommandBridge::new(webview)
-  bridge.handle("sum", fn(payload : SumPayload) {
-    let reply = SumReply::{ total: payload.left + payload.right }
+  bridge.handle_result("sum", fn(payload : SumPayload) {
+    let reply =
+      if payload.right < 0 {
+        Err("right must be non-negative")
+      } else {
+        Ok(SumReply::{ total: payload.left + payload.right })
+      }
     bridge.send("notice", NoticePayload::{
-      message: "MoonBit computed " + reply.total.to_string(),
+      message: "MoonBit handled sum",
     })
     reply
   })
@@ -155,7 +175,14 @@ fn main {
     #|   });
     #|   window.MoonBitBridge
     #|     .send("sum", { left: 1, right: 2 })
-    #|     .then(console.log);
+    #|     .then((response) => {
+    #|       if (response.status === "ok") {
+    #|         console.log("MoonBit reply", response.payload);
+    #|       } else {
+    #|         console.error("MoonBit command error", response.error);
+    #|       }
+    #|     })
+    #|     .catch(console.error);
     #| </script>,
   )
   webview.run()

--- a/examples/16_command/main.mbt
+++ b/examples/16_command/main.mbt
@@ -67,12 +67,12 @@ let html =
   #|       document.getElementById("run").addEventListener("click", () => {
   #|         window.MoonBitBridge
   #|           .send("sum", { left: 7, right: 8 })
-  #|           .then((result) => {
+  #|           .then((response) => {
   #|             output.textContent =
-  #|               "Command reply:\n" + JSON.stringify(result, null, 2);
+  #|               "Command response:\n" + JSON.stringify(response, null, 2);
   #|           })
   #|           .catch((error) => {
-  #|             output.textContent = String(error);
+  #|             output.textContent = "Transport error:\n" + String(error);
   #|           });
   #|       });
   #|     </script>

--- a/examples/16_command/main.mbt
+++ b/examples/16_command/main.mbt
@@ -1,0 +1,96 @@
+struct SumPayload {
+  left : Int
+  right : Int
+} derive(ToJson, FromJson, Eq, Show)
+
+struct SumReply {
+  total : Int
+} derive(ToJson, FromJson, Eq, Show)
+
+struct NativeNotice {
+  message : String
+} derive(ToJson, FromJson, Eq, Show)
+
+let html =
+  #| <html>
+  #|   <head>
+  #|     <style>
+  #|       body {
+  #|         margin: 0;
+  #|         min-height: 100vh;
+  #|         display: grid;
+  #|         place-items: center;
+  #|         background: linear-gradient(135deg, #f4f0e8 0%, #dbe7f3 100%);
+  #|         color: #172028;
+  #|         font-family: "Iowan Old Style", "Palatino Linotype", serif;
+  #|       }
+  #|       main {
+  #|         width: min(32rem, calc(100vw - 3rem));
+  #|         padding: 2rem;
+  #|         border-radius: 20px;
+  #|         background: rgba(255, 255, 255, 0.84);
+  #|         box-shadow: 0 20px 60px rgba(23, 32, 40, 0.12);
+  #|       }
+  #|       button {
+  #|         border: 0;
+  #|         border-radius: 999px;
+  #|         padding: 0.85rem 1.2rem;
+  #|         background: #172028;
+  #|         color: white;
+  #|         font: inherit;
+  #|         cursor: pointer;
+  #|       }
+  #|       pre {
+  #|         margin-top: 1rem;
+  #|         padding: 1rem;
+  #|         border-radius: 14px;
+  #|         background: #eef3f8;
+  #|         white-space: pre-wrap;
+  #|       }
+  #|     </style>
+  #|   </head>
+  #|   <body>
+  #|     <main>
+  #|       <h1>Command Bridge</h1>
+  #|       <p>JavaScript sends a command to MoonBit, MoonBit responds, then emits a native event back into the page.</p>
+  #|       <button id="run">Run command</button>
+  #|       <pre id="output">Click the button.</pre>
+  #|     </main>
+  #|     <script>
+  #|       const output = document.getElementById("output");
+  #|       window.MoonBitBridge.onCommand((command) => {
+  #|         if (command.name === "notice") {
+  #|           output.textContent =
+  #|             "Native event:\n" + JSON.stringify(command.payload, null, 2);
+  #|         }
+  #|       });
+  #|       document.getElementById("run").addEventListener("click", () => {
+  #|         window.MoonBitBridge
+  #|           .send("sum", { left: 7, right: 8 })
+  #|           .then((result) => {
+  #|             output.textContent =
+  #|               "Command reply:\n" + JSON.stringify(result, null, 2);
+  #|           })
+  #|           .catch((error) => {
+  #|             output.textContent = String(error);
+  #|           });
+  #|       });
+  #|     </script>
+  #|   </body>
+  #| </html>
+
+fn main {
+  let webview = @webview.Webview::new(debug=1)
+  let bridge = @webview.CommandBridge::new(webview)
+  bridge.handle("sum", fn(payload : SumPayload) {
+    let reply = SumReply::{ total: payload.left + payload.right }
+    bridge.send("notice", NativeNotice::{
+      message: "MoonBit computed " + reply.total.to_string(),
+    })
+    reply
+  })
+  webview.set_title("MoonBit Command Bridge")
+  webview.set_size(860, 640, @webview.SizeHint::None)
+  webview.set_html(html)
+  webview.run()
+}

--- a/examples/16_command/moon.pkg
+++ b/examples/16_command/moon.pkg
@@ -1,10 +1,10 @@
 import {
   "moonbitlang/core/json",
-  "justjavac/ffi",
   "justjavac/webview",
 }
 
 options(
+  "is-main": true,
   link: {
     "native": {
       "cc-flags": "-fwrapv -fsanitize=address -fsanitize=undefined",
@@ -12,5 +12,5 @@ options(
     },
   },
   "supported-targets": [ "native" ],
-  targets: { "webview_test": [ "native" ] },
+  targets: { "main.mbt": [ "native" ] },
 )

--- a/examples/Readme.md
+++ b/examples/Readme.md
@@ -15,3 +15,4 @@
 | 11_multi_window | ✓      |                                         |
 | 12_embed        | ✓      |                                         |
 | 13_todo         | ✓      |                                         |
+| 16_command      | ✓      | Structured JS <-> MoonBit bridge       |

--- a/src/command.mbt
+++ b/src/command.mbt
@@ -70,19 +70,30 @@ pub fn[Payload : @json.FromJson, Reply : ToJson] CommandBridge::handle(
 
 ///|
 /// Emits a named command from MoonBit to JavaScript.
+///
+/// The JS dispatch is scheduled onto the webview event loop so this remains
+/// safe to call off the UI thread.
 pub fn[Payload : ToJson] CommandBridge::send(
   self : CommandBridge,
   name : String,
   payload : Payload,
 ) -> Unit {
   let command = Command::{ name, payload: ToJson::to_json(payload) }
-  self.webview.eval(
-    make_command_dispatch_script(
-      self.global_name,
-      self.event_name,
-      command.to_json().stringify(),
-    ),
+  let script = make_command_dispatch_script(
+    self.global_name,
+    self.event_name,
+    command.to_json().stringify(),
   )
+  self.webview.dispatch(fn() { self.webview.eval(script) })
+}
+
+///|
+fn CommandBridge::respond_error(
+  self : CommandBridge,
+  id : String,
+  message : String,
+) -> Unit {
+  self.webview.response(id, 1, Json::string(message).stringify())
 }
 
 ///|
@@ -98,11 +109,11 @@ fn CommandBridge::handle_request(
         Some(handler) =>
           match handler(command.payload) {
             Ok(result) => self.webview.response(id, 0, result.stringify())
-            Err(message) => self.webview.response(id, 1, message)
+            Err(message) => self.respond_error(id, message)
           }
-        None => self.webview.response(id, 1, "Unknown command: " + command.name)
+        None => self.respond_error(id, "Unknown command: " + command.name)
       }
-    Err(message) => self.webview.response(id, 1, message)
+    Err(message) => self.respond_error(id, message)
   }
 }
 

--- a/src/command.mbt
+++ b/src/command.mbt
@@ -28,16 +28,13 @@ pub fn CommandBridge::new(
   binding_name? : String = "__moonbit_command",
   event_name? : String = "moonbit:command",
 ) -> CommandBridge {
-  let bridge = CommandBridge::{
-    webview,
-    global_name,
-    event_name,
-    handlers: {},
-  }
+  let bridge = CommandBridge::{ webview, global_name, event_name, handlers: {} }
   bridge.webview.bind(binding_name, fn(id, req) {
     bridge.handle_request(id, req)
   })
-  bridge.webview.init(make_command_bridge_script(global_name, binding_name, event_name))
+  bridge.webview.init(
+    make_command_bridge_script(global_name, binding_name, event_name),
+  )
   bridge
 }
 
@@ -79,13 +76,16 @@ pub fn[Payload : ToJson] CommandBridge::send(
   payload : Payload,
 ) -> Unit {
   let command = Command::{ name, payload: ToJson::to_json(payload) }
-  self.webview.eval(make_command_dispatch_script(
-    self.global_name,
-    self.event_name,
-    command.to_json().stringify(),
-  ))
+  self.webview.eval(
+    make_command_dispatch_script(
+      self.global_name,
+      self.event_name,
+      command.to_json().stringify(),
+    ),
+  )
 }
 
+///|
 fn CommandBridge::handle_request(
   self : CommandBridge,
   raw_id : Bytes,
@@ -106,12 +106,15 @@ fn CommandBridge::handle_request(
   }
 }
 
+///|
 fn parse_command_request(raw_req : String) -> Result[Command, String] {
   let request_json : Result[Json, _] = try? @json.parse(raw_req)
   match request_json {
     Err(err) => Err(err.to_string())
     Ok(request_json) => {
-      let request_args : Result[Array[Command], _] = try? @json.from_json(request_json)
+      let request_args : Result[Array[Command], _] = try? @json.from_json(
+        request_json,
+      )
       match request_args {
         Err(err) => Err(err.to_string())
         Ok(request_args) =>
@@ -125,6 +128,7 @@ fn parse_command_request(raw_req : String) -> Result[Command, String] {
   }
 }
 
+///|
 fn make_command_bridge_script(
   global_name : String,
   binding_name : String,
@@ -162,6 +166,7 @@ fn make_command_bridge_script(
   "})();"
 }
 
+///|
 fn make_command_dispatch_script(
   global_name : String,
   event_name : String,

--- a/src/command.mbt
+++ b/src/command.mbt
@@ -63,9 +63,14 @@ pub fn CommandResponse::is_ok(self : CommandResponse) -> Bool {
 ///
 /// JS -> MoonBit resolves to a `CommandResponse`, so command-level failures are
 /// encoded in the response object instead of rejecting the promise.
+///
+/// `CommandBridge::new(...)` aborts if `binding_name` is already bound on the
+/// target `Webview`, because duplicate internal bindings would leave the new
+/// bridge unreachable from JavaScript.
 struct CommandBridge {
   webview : Webview
   global_name : String
+  binding_name : String
   event_name : String
   handlers : Map[String, (Json) -> CommandResponse]
 }
@@ -79,15 +84,27 @@ struct CommandBridge {
 ///
 /// Parameters:
 /// - `global_name` controls the injected `window[...]` object name
-/// - `binding_name` controls the internal JS -> MoonBit webview binding name
+/// - `binding_name` controls the internal JS -> MoonBit webview binding name;
+///   it must be unique per `Webview`
 /// - `event_name` controls the browser event used for MoonBit -> JS delivery
+///
+/// This function aborts if `binding_name` is already registered on `webview`.
 pub fn CommandBridge::new(
   webview : Webview,
   global_name? : String = "MoonBitBridge",
   binding_name? : String = "__moonbit_command",
   event_name? : String = "moonbit:command",
 ) -> CommandBridge {
-  let bridge = CommandBridge::{ webview, global_name, event_name, handlers: {} }
+  guard webview.bindings.get(binding_name) is None else {
+    abort("CommandBridge::new: binding name already in use: " + binding_name)
+  }
+  let bridge = CommandBridge::{
+    webview,
+    global_name,
+    binding_name,
+    event_name,
+    handlers: {},
+  }
   bridge.webview.bind(binding_name, fn(id, req) {
     bridge.handle_request(id, req)
   })
@@ -107,6 +124,20 @@ pub fn CommandBridge::global_name(self : CommandBridge) -> String {
 /// Returns the browser event name used for native-to-JS commands.
 pub fn CommandBridge::event_name(self : CommandBridge) -> String {
   self.event_name
+}
+
+///|
+/// Unregisters the bridge's internal JS -> MoonBit binding and drops all
+/// registered handlers.
+///
+/// This does not destroy the underlying `Webview`.
+///
+/// The JS bootstrap installed with `webview.init(...)` cannot be retracted for
+/// future page loads, but after `destroy()` the old bridge binding is no longer
+/// callable and the same `binding_name` can be reused for a new bridge.
+pub fn CommandBridge::destroy(self : CommandBridge) -> Unit {
+  self.handlers.clear()
+  self.webview.unbind(self.binding_name)
 }
 
 ///|

--- a/src/command.mbt
+++ b/src/command.mbt
@@ -1,0 +1,187 @@
+///|
+/// A named command exchanged between JavaScript and MoonBit.
+pub struct Command {
+  name : String
+  payload : Json
+} derive(ToJson, FromJson, Show, Eq)
+
+///|
+/// High-level JSON command bridge built on top of `webview.bind()`.
+///
+/// It injects a JS helper object into the page and routes named commands to
+/// registered MoonBit handlers.
+struct CommandBridge {
+  webview : Webview
+  global_name : String
+  event_name : String
+  handlers : Map[String, (Json) -> Result[Json, String]]
+}
+
+///|
+/// Creates and installs a command bridge for the given webview.
+///
+/// On the JavaScript side this exposes `window[global_name].send(name, payload)`
+/// and `window[global_name].onCommand(listener)`.
+pub fn CommandBridge::new(
+  webview : Webview,
+  global_name? : String = "MoonBitBridge",
+  binding_name? : String = "__moonbit_command",
+  event_name? : String = "moonbit:command",
+) -> CommandBridge {
+  let bridge = CommandBridge::{
+    webview,
+    global_name,
+    event_name,
+    handlers: {},
+  }
+  bridge.webview.bind(binding_name, fn(id, req) {
+    bridge.handle_request(id, req)
+  })
+  bridge.webview.init(make_command_bridge_script(global_name, binding_name, event_name))
+  bridge
+}
+
+///|
+/// Returns the injected global object name on the JS side.
+pub fn CommandBridge::global_name(self : CommandBridge) -> String {
+  self.global_name
+}
+
+///|
+/// Returns the browser event name used for native-to-JS commands.
+pub fn CommandBridge::event_name(self : CommandBridge) -> String {
+  self.event_name
+}
+
+///|
+/// Registers a typed command handler.
+///
+/// Use `Json` as `Payload` if you want to handle raw JSON directly.
+pub fn[Payload : @json.FromJson, Reply : ToJson] CommandBridge::handle(
+  self : CommandBridge,
+  name : String,
+  callback : (Payload) -> Reply,
+) -> Unit {
+  self.handlers.set(name, fn(payload_json) {
+    let payload : Result[Payload, _] = try? @json.from_json(payload_json)
+    match payload {
+      Ok(payload) => Ok(ToJson::to_json(callback(payload)))
+      Err(err) => Err(err.to_string())
+    }
+  })
+}
+
+///|
+/// Emits a named command from MoonBit to JavaScript.
+pub fn[Payload : ToJson] CommandBridge::send(
+  self : CommandBridge,
+  name : String,
+  payload : Payload,
+) -> Unit {
+  let command = Command::{ name, payload: ToJson::to_json(payload) }
+  self.webview.eval(make_command_dispatch_script(
+    self.global_name,
+    self.event_name,
+    command.to_json().stringify(),
+  ))
+}
+
+fn CommandBridge::handle_request(
+  self : CommandBridge,
+  raw_id : Bytes,
+  raw_req : Bytes,
+) -> Unit {
+  let id = @ffi.from_cstr(raw_id)
+  match parse_command_request(@ffi.from_cstr(raw_req)) {
+    Ok(command) =>
+      match self.handlers.get(command.name) {
+        Some(handler) =>
+          match handler(command.payload) {
+            Ok(result) => self.webview.response(id, 0, result.stringify())
+            Err(message) => self.webview.response(id, 1, message)
+          }
+        None => self.webview.response(id, 1, "Unknown command: " + command.name)
+      }
+    Err(message) => self.webview.response(id, 1, message)
+  }
+}
+
+fn parse_command_request(raw_req : String) -> Result[Command, String] {
+  let request_json : Result[Json, _] = try? @json.parse(raw_req)
+  match request_json {
+    Err(err) => Err(err.to_string())
+    Ok(request_json) => {
+      let request_args : Result[Array[Command], _] = try? @json.from_json(request_json)
+      match request_args {
+        Err(err) => Err(err.to_string())
+        Ok(request_args) =>
+          if request_args.length() == 1 {
+            Ok(request_args[0])
+          } else {
+            Err("Expected exactly one command argument")
+          }
+      }
+    }
+  }
+}
+
+fn make_command_bridge_script(
+  global_name : String,
+  binding_name : String,
+  event_name : String,
+) -> String {
+  let global_name_js = Json::string(global_name).stringify()
+  let binding_name_js = Json::string(binding_name).stringify()
+  let event_name_js = Json::string(event_name).stringify()
+  "(function() {" +
+  "  const globalName = " +
+  global_name_js +
+  ";" +
+  "  const bindingName = " +
+  binding_name_js +
+  ";" +
+  "  const eventName = " +
+  event_name_js +
+  ";" +
+  "  function dispatch(command) {" +
+  "    window.dispatchEvent(new CustomEvent(eventName, { detail: command }));" +
+  "  }" +
+  "  window[globalName] = {" +
+  "    send: function(name, payload) {" +
+  "      const command = { name: name, payload: payload === undefined ? null : payload };" +
+  "      return window[bindingName](command);" +
+  "    }," +
+  "    onCommand: function(listener) {" +
+  "      const handler = function(event) { listener(event.detail); };" +
+  "      window.addEventListener(eventName, handler);" +
+  "      return function() { window.removeEventListener(eventName, handler); };" +
+  "    }," +
+  "    __dispatchCommand: dispatch," +
+  "    eventName: eventName" +
+  "  };" +
+  "})();"
+}
+
+fn make_command_dispatch_script(
+  global_name : String,
+  event_name : String,
+  command_json : String,
+) -> String {
+  let global_name_js = Json::string(global_name).stringify()
+  let event_name_js = Json::string(event_name).stringify()
+  "(function() {" +
+  "  const command = " +
+  command_json +
+  ";" +
+  "  const bridge = window[" +
+  global_name_js +
+  "];" +
+  "  if (bridge && bridge.__dispatchCommand) {" +
+  "    bridge.__dispatchCommand(command);" +
+  "    return;" +
+  "  }" +
+  "  window.dispatchEvent(new CustomEvent(" +
+  event_name_js +
+  ", { detail: command }));" +
+  "})();"
+}

--- a/src/command.mbt
+++ b/src/command.mbt
@@ -1,27 +1,86 @@
 ///|
 /// A named command exchanged between JavaScript and MoonBit.
+///
+/// `name` is the logical command identifier and `payload` is arbitrary JSON.
+/// This shape is used in both directions:
+/// - JS -> MoonBit via `window.MoonBitBridge.send(name, payload)`
+/// - MoonBit -> JS via `CommandBridge::send(name, payload)`
 pub struct Command {
   name : String
   payload : Json
 } derive(ToJson, FromJson, Show, Eq)
 
 ///|
+/// Structured response returned from JS -> MoonBit commands.
+///
+/// `status` is `"ok"` for successful handlers and `"error"` for command
+/// decode/dispatch failures or explicit handler errors.
+///
+/// When `status == "ok"`, `payload` contains the JSON-encoded reply and
+/// `error` is `None`.
+///
+/// When `status == "error"`, `error` contains the failure message and
+/// `payload` is `None`.
+pub struct CommandResponse {
+  status : String
+  payload : Json?
+  error : String?
+} derive(ToJson, FromJson, Show, Eq)
+
+///|
+/// Builds a successful command response.
+pub fn[Payload : ToJson] CommandResponse::ok(
+  payload : Payload,
+) -> CommandResponse {
+  CommandResponse::{
+    status: "ok",
+    payload: Some(ToJson::to_json(payload)),
+    error: None,
+  }
+}
+
+///|
+/// Builds a failed command response.
+pub fn CommandResponse::error(message : String) -> CommandResponse {
+  CommandResponse::{ status: "error", payload: None, error: Some(message) }
+}
+
+///|
+/// Returns `true` when the response status is `"ok"`.
+pub fn CommandResponse::is_ok(self : CommandResponse) -> Bool {
+  self.status == "ok"
+}
+
+///|
 /// High-level JSON command bridge built on top of `webview.bind()`.
 ///
 /// It injects a JS helper object into the page and routes named commands to
 /// registered MoonBit handlers.
+///
+/// The injected JS helper exposes:
+/// - `window[global_name].send(name, payload)` for JS -> MoonBit request/reply
+/// - `window[global_name].onCommand(listener)` for MoonBit -> JS events
+///
+/// JS -> MoonBit resolves to a `CommandResponse`, so command-level failures are
+/// encoded in the response object instead of rejecting the promise.
 struct CommandBridge {
   webview : Webview
   global_name : String
   event_name : String
-  handlers : Map[String, (Json) -> Result[Json, String]]
+  handlers : Map[String, (Json) -> CommandResponse]
 }
 
 ///|
 /// Creates and installs a command bridge for the given webview.
 ///
-/// On the JavaScript side this exposes `window[global_name].send(name, payload)`
-/// and `window[global_name].onCommand(listener)`.
+/// On the JavaScript side this exposes:
+/// - `window[global_name].send(name, payload)` returning `Promise<CommandResponse>`
+/// - `window[global_name].onCommand(listener)` for MoonBit -> JS events
+///
+/// Parameters:
+/// - `global_name` controls the injected `window[...]` object name
+/// - `binding_name` controls the internal JS -> MoonBit webview binding name
+/// - `event_name` controls the browser event used for MoonBit -> JS delivery
 pub fn CommandBridge::new(
   webview : Webview,
   global_name? : String = "MoonBitBridge",
@@ -54,6 +113,14 @@ pub fn CommandBridge::event_name(self : CommandBridge) -> String {
 /// Registers a typed command handler.
 ///
 /// Use `Json` as `Payload` if you want to handle raw JSON directly.
+///
+/// When JS calls `window.MoonBitBridge.send(name, payload)`, the bridge:
+/// - looks up the handler registered under `name`
+/// - decodes `payload` into `Payload`
+/// - encodes the callback result into `CommandResponse::{ status, payload, error }`
+///
+/// If payload decoding fails, no handler exists, or the request shape is
+/// invalid, the returned `CommandResponse` has `status == "error"`.
 pub fn[Payload : @json.FromJson, Reply : ToJson] CommandBridge::handle(
   self : CommandBridge,
   name : String,
@@ -62,8 +129,31 @@ pub fn[Payload : @json.FromJson, Reply : ToJson] CommandBridge::handle(
   self.handlers.set(name, fn(payload_json) {
     let payload : Result[Payload, _] = try? @json.from_json(payload_json)
     match payload {
-      Ok(payload) => Ok(ToJson::to_json(callback(payload)))
-      Err(err) => Err(err.to_string())
+      Ok(payload) => CommandResponse::ok(callback(payload))
+      Err(err) => CommandResponse::error(err.to_string())
+    }
+  })
+}
+
+///|
+/// Registers a typed command handler that can return explicit command errors.
+///
+/// Use this when the handler needs to reply with `Result[Reply, String]` rather
+/// than treating every failure as a transport/runtime exception.
+pub fn[Payload : @json.FromJson, Reply : ToJson] CommandBridge::handle_result(
+  self : CommandBridge,
+  name : String,
+  callback : (Payload) -> Result[Reply, String],
+) -> Unit {
+  self.handlers.set(name, fn(payload_json) {
+    let payload : Result[Payload, _] = try? @json.from_json(payload_json)
+    match payload {
+      Ok(payload) =>
+        match callback(payload) {
+          Ok(reply) => CommandResponse::ok(reply)
+          Err(message) => CommandResponse::error(message)
+        }
+      Err(err) => CommandResponse::error(err.to_string())
     }
   })
 }
@@ -73,6 +163,10 @@ pub fn[Payload : @json.FromJson, Reply : ToJson] CommandBridge::handle(
 ///
 /// The JS dispatch is scheduled onto the webview event loop so this remains
 /// safe to call off the UI thread.
+///
+/// This is a fire-and-forget notification API. It does not wait for a JS
+/// response. JavaScript receives the command through
+/// `window.MoonBitBridge.onCommand(listener)` as a `Command`-shaped object.
 pub fn[Payload : ToJson] CommandBridge::send(
   self : CommandBridge,
   name : String,
@@ -88,12 +182,12 @@ pub fn[Payload : ToJson] CommandBridge::send(
 }
 
 ///|
-fn CommandBridge::respond_error(
+fn CommandBridge::respond(
   self : CommandBridge,
   id : String,
-  message : String,
+  response : CommandResponse,
 ) -> Unit {
-  self.webview.response(id, 1, Json::string(message).stringify())
+  self.webview.response(id, 0, response.to_json().stringify())
 }
 
 ///|
@@ -103,22 +197,21 @@ fn CommandBridge::handle_request(
   raw_req : Bytes,
 ) -> Unit {
   let id = @ffi.from_cstr(raw_id)
-  match parse_command_request(@ffi.from_cstr(raw_req)) {
+  let response = match parse_command_request(@ffi.from_cstr(raw_req)) {
     Ok(command) =>
       match self.handlers.get(command.name) {
-        Some(handler) =>
-          match handler(command.payload) {
-            Ok(result) => self.webview.response(id, 0, result.stringify())
-            Err(message) => self.respond_error(id, message)
-          }
-        None => self.respond_error(id, "Unknown command: " + command.name)
+        Some(handler) => handler(command.payload)
+        None => CommandResponse::error("Unknown command: " + command.name)
       }
-    Err(message) => self.respond_error(id, message)
+    Err(message) => CommandResponse::error(message)
   }
+  self.respond(id, response)
 }
 
 ///|
 fn parse_command_request(raw_req : String) -> Result[Command, String] {
+  // A webview binding receives its JS arguments as a JSON array. The bridge
+  // expects exactly one argument: the `{ name, payload }` command object.
   let request_json : Result[Json, _] = try? @json.parse(raw_req)
   match request_json {
     Err(err) => Err(err.to_string())
@@ -145,6 +238,8 @@ fn make_command_bridge_script(
   binding_name : String,
   event_name : String,
 ) -> String {
+  // Install a tiny JS runtime helper for request/reply (`send`) and
+  // fire-and-forget native events (`onCommand`).
   let global_name_js = Json::string(global_name).stringify()
   let binding_name_js = Json::string(binding_name).stringify()
   let event_name_js = Json::string(event_name).stringify()
@@ -183,6 +278,8 @@ fn make_command_dispatch_script(
   event_name : String,
   command_json : String,
 ) -> String {
+  // Reuse the injected helper when it exists so both directions share the
+  // same event path. Fall back to dispatching the browser event directly.
   let global_name_js = Json::string(global_name).stringify()
   let event_name_js = Json::string(event_name).stringify()
   "(function() {" +

--- a/src/moon.pkg
+++ b/src/moon.pkg
@@ -1,4 +1,5 @@
 import {
+  "moonbitlang/core/json",
   "justjavac/ffi",
 }
 
@@ -11,5 +12,9 @@ options(
   },
   "native-stub": [ "stub.c" ],
   "supported-targets": [ "native" ],
-  targets: { "binding.mbt": [ "native" ], "webview.mbt": [ "native" ] },
+  targets: {
+    "binding.mbt": [ "native" ],
+    "command.mbt": [ "native" ],
+    "webview.mbt": [ "native" ],
+  },
 )

--- a/src/pkg.generated.mbti
+++ b/src/pkg.generated.mbti
@@ -60,8 +60,22 @@ type CommandBridge
 pub fn CommandBridge::event_name(Self) -> String
 pub fn CommandBridge::global_name(Self) -> String
 pub fn[Payload : @json.FromJson, Reply : ToJson] CommandBridge::handle(Self, String, (Payload) -> Reply) -> Unit
+pub fn[Payload : @json.FromJson, Reply : ToJson] CommandBridge::handle_result(Self, String, (Payload) -> Result[Reply, String]) -> Unit
 pub fn CommandBridge::new(Webview, global_name? : String, binding_name? : String, event_name? : String) -> Self
 pub fn[Payload : ToJson] CommandBridge::send(Self, String, Payload) -> Unit
+
+pub struct CommandResponse {
+  status : String
+  payload : Json?
+  error : String?
+}
+pub fn CommandResponse::error(String) -> Self
+pub fn CommandResponse::is_ok(Self) -> Bool
+pub fn[Payload : ToJson] CommandResponse::ok(Payload) -> Self
+pub impl Eq for CommandResponse
+pub impl Show for CommandResponse
+pub impl ToJson for CommandResponse
+pub impl @json.FromJson for CommandResponse
 
 pub(all) enum NativeHandleKind {
   Window

--- a/src/pkg.generated.mbti
+++ b/src/pkg.generated.mbti
@@ -1,6 +1,10 @@
 // Generated using `moon info`, DON'T EDIT IT
 package "justjavac/webview"
 
+import {
+  "moonbitlang/core/json",
+}
+
 // Values
 pub fn webview_bind(Webview_t, Bytes, FuncRef[(CStr, CStr, (Bytes, Bytes) -> Unit) -> Unit], (Bytes, Bytes) -> Unit) -> BindingHandle
 
@@ -42,6 +46,22 @@ pub type BindingHandle
 
 #external
 pub type CStr
+
+pub struct Command {
+  name : String
+  payload : Json
+}
+pub impl Eq for Command
+pub impl Show for Command
+pub impl ToJson for Command
+pub impl @json.FromJson for Command
+
+type CommandBridge
+pub fn CommandBridge::event_name(Self) -> String
+pub fn CommandBridge::global_name(Self) -> String
+pub fn[Payload : @json.FromJson, Reply : ToJson] CommandBridge::handle(Self, String, (Payload) -> Reply) -> Unit
+pub fn CommandBridge::new(Webview, global_name? : String, binding_name? : String, event_name? : String) -> Self
+pub fn[Payload : ToJson] CommandBridge::send(Self, String, Payload) -> Unit
 
 pub(all) enum NativeHandleKind {
   Window

--- a/src/pkg.generated.mbti
+++ b/src/pkg.generated.mbti
@@ -57,6 +57,7 @@ pub impl ToJson for Command
 pub impl @json.FromJson for Command
 
 type CommandBridge
+pub fn CommandBridge::destroy(Self) -> Unit
 pub fn CommandBridge::event_name(Self) -> String
 pub fn CommandBridge::global_name(Self) -> String
 pub fn[Payload : @json.FromJson, Reply : ToJson] CommandBridge::handle(Self, String, (Payload) -> Reply) -> Unit

--- a/test/webview_test.mbt
+++ b/test/webview_test.mbt
@@ -14,12 +14,14 @@ struct NativeEvent {
 } derive(ToJson, FromJson, Eq, Show)
 
 ///|
-fn decode_single_string_argument(raw_req : Bytes) -> Result[String, String] {
+fn[Payload : @json.FromJson] decode_single_argument(
+  raw_req : Bytes,
+) -> Result[Payload, String] {
   let request_json : Result[Json, _] = try? @json.parse(@ffi.from_cstr(raw_req))
   match request_json {
     Err(err) => Err(err.to_string())
     Ok(request_json) => {
-      let request_args : Result[Array[String], _] = try? @json.from_json(
+      let request_args : Result[Array[Payload], _] = try? @json.from_json(
         request_json,
       )
       match request_args {
@@ -28,7 +30,7 @@ fn decode_single_string_argument(raw_req : Bytes) -> Result[String, String] {
           if request_args.length() == 1 {
             Ok(request_args[0])
           } else {
-            Err("Expected exactly one string argument")
+            Err("Expected exactly one argument")
           }
       }
     }
@@ -97,21 +99,23 @@ test "Command bridge exchanges typed commands with JavaScript" {
     echoed: "hello from js / handled by MoonBit",
     next_count: 4,
   }
+  let expected_response = @webview.CommandResponse::ok(expected_reply)
   let expected_event = NativeEvent::{ label: "native-ready", total: 6 }
   let mut seen_ping : PingPayload? = None
-  let mut seen_reply : PingReply? = None
+  let mut seen_response : @webview.CommandResponse? = None
   let mut seen_event : NativeEvent? = None
   let mut js_error : String? = None
   let webview = @webview.Webview::new()
   let bridge = @webview.CommandBridge::new(webview)
   let finish = fn() {
-    if seen_reply is Some(_) && seen_event is Some(_) {
+    if seen_response is Some(_) && seen_event is Some(_) {
       webview.terminate()
     }
   }
   webview.bind("reportTestFailure", fn(id, req) {
     let request_id = @ffi.from_cstr(id)
-    match decode_single_string_argument(req) {
+    let message_result : Result[String, String] = decode_single_argument(req)
+    match message_result {
       Ok(message) => js_error = Some(message)
       Err(message) =>
         js_error = Some("Failed to decode JS failure payload: " + message)
@@ -119,14 +123,31 @@ test "Command bridge exchanges typed commands with JavaScript" {
     webview.response(request_id, 0, "null")
     webview.terminate()
   })
+  webview.bind("reportPingResponse", fn(id, req) {
+    let request_id = @ffi.from_cstr(id)
+    let response_result : Result[@webview.CommandResponse, String] =
+      decode_single_argument(req)
+    match response_result {
+      Ok(response) => {
+        seen_response = Some(response)
+        webview.response(request_id, 0, "null")
+        if response.is_ok() {
+          finish()
+        } else {
+          webview.terminate()
+        }
+      }
+      Err(message) => {
+        js_error = Some("Failed to decode command response payload: " + message)
+        webview.response(request_id, 0, "null")
+        webview.terminate()
+      }
+    }
+  })
   bridge.handle("ping", fn(payload : PingPayload) {
     seen_ping = Some(payload)
     bridge.send("nativeEvent", expected_event)
     expected_reply
-  })
-  bridge.handle("jsResult", fn(payload : PingReply) {
-    seen_reply = Some(payload)
-    finish()
   })
   bridge.handle("jsObservedNativeEvent", fn(payload : NativeEvent) {
     seen_event = Some(payload)
@@ -145,6 +166,8 @@ test "Command bridge exchanges typed commands with JavaScript" {
       #|       window.addEventListener("unhandledrejection", (event) => {
       #|         void reportFailure("unhandled rejection: " + String(event.reason));
       #|       });
+      #|       const reportPingResponse = (response) =>
+      #|         window.reportPingResponse(response).catch(() => {});
       #|       window.addEventListener("load", () => {
       #|         const bridge = window.MoonBitBridge;
       #|         bridge.onCommand((command) => {
@@ -158,9 +181,13 @@ test "Command bridge exchanges typed commands with JavaScript" {
       #|         });
       #|         bridge
       #|           .send("ping", { message: "hello from js", count: 3 })
-      #|           .then((result) => bridge.send("jsResult", result))
+      #|           .then((response) => reportPingResponse(response))
       #|           .catch((error) => {
-      #|             return reportFailure("ping error: " + String(error));
+      #|             return reportPingResponse({
+      #|               status: "transport_error",
+      #|               payload: null,
+      #|               error: String(error),
+      #|             });
       #|           });
       #|       });
       #|     </script>
@@ -170,22 +197,32 @@ test "Command bridge exchanges typed commands with JavaScript" {
   )
   webview.run()
   assert_eq(seen_ping, Some(expected_ping))
-  assert_eq(seen_reply, Some(expected_reply))
+  assert_eq(seen_response, Some(expected_response))
   assert_eq(seen_event, Some(expected_event))
   assert_eq(js_error, None)
 }
 
 ///|
-test "Command bridge rejects unknown commands with JSON string errors" {
-  let mut seen_error : String? = None
+test "Command bridge returns structured errors for unknown commands" {
+  let expected_response = @webview.CommandResponse::error(
+    "Unknown command: missing",
+  )
+  let mut seen_response : @webview.CommandResponse? = None
   let webview = @webview.Webview::new()
   let _bridge = @webview.CommandBridge::new(webview)
   webview.bind("reportUnknownCommandError", fn(id, req) {
     let request_id = @ffi.from_cstr(id)
-    match decode_single_string_argument(req) {
-      Ok(message) => seen_error = Some(message)
-      Err(message) =>
-        seen_error = Some("Failed to decode unknown-command payload: " + message)
+    let response_result : Result[@webview.CommandResponse, String] =
+      decode_single_argument(req)
+    match response_result {
+      Ok(response) => seen_response = Some(response)
+      Err(message) => {
+        seen_response = Some(
+          @webview.CommandResponse::error(
+            "Failed to decode unknown-command payload: " + message,
+          ),
+        )
+      }
     }
     webview.response(request_id, 0, "null")
     webview.terminate()
@@ -196,12 +233,17 @@ test "Command bridge rejects unknown commands with JSON string errors" {
       #|   <body>
       #|     <script>
       #|       window.addEventListener("load", () => {
-      #|         const reportResult = (message) =>
-      #|           window.reportUnknownCommandError(message).catch(() => {});
+      #|         const reportResult = (response) =>
+      #|           window.reportUnknownCommandError(response).catch(() => {});
       #|         window.MoonBitBridge
       #|           .send("missing", { ok: true })
-      #|           .then(() => reportResult("unexpected success"))
-      #|           .catch((error) => reportResult(String(error)));
+      #|           .then((response) => reportResult(response))
+      #|           .catch((error) =>
+      #|             reportResult({
+      #|               status: "transport_error",
+      #|               payload: null,
+      #|               error: String(error),
+      #|             }));
       #|       });
       #|     </script>
       #|   </body>
@@ -209,5 +251,5 @@ test "Command bridge rejects unknown commands with JSON string errors" {
     ),
   )
   webview.run()
-  assert_eq(seen_error, Some("Unknown command: missing"))
+  assert_eq(seen_response, Some(expected_response))
 }

--- a/test/webview_test.mbt
+++ b/test/webview_test.mbt
@@ -14,6 +14,28 @@ struct NativeEvent {
 } derive(ToJson, FromJson, Eq, Show)
 
 ///|
+fn decode_single_string_argument(raw_req : Bytes) -> Result[String, String] {
+  let request_json : Result[Json, _] = try? @json.parse(@ffi.from_cstr(raw_req))
+  match request_json {
+    Err(err) => Err(err.to_string())
+    Ok(request_json) => {
+      let request_args : Result[Array[String], _] = try? @json.from_json(
+        request_json,
+      )
+      match request_args {
+        Err(err) => Err(err.to_string())
+        Ok(request_args) =>
+          if request_args.length() == 1 {
+            Ok(request_args[0])
+          } else {
+            Err("Expected exactly one string argument")
+          }
+      }
+    }
+  }
+}
+
+///|
 test "Start app loop and terminate it" {
   let webview = @webview.Webview::new()
   webview.dispatch(fn() { webview.terminate() })
@@ -79,6 +101,7 @@ test "Command bridge exchanges typed commands with JavaScript" {
   let mut seen_ping : PingPayload? = None
   let mut seen_reply : PingReply? = None
   let mut seen_event : NativeEvent? = None
+  let mut js_error : String? = None
   let webview = @webview.Webview::new()
   let bridge = @webview.CommandBridge::new(webview)
   let finish = fn() {
@@ -86,6 +109,16 @@ test "Command bridge exchanges typed commands with JavaScript" {
       webview.terminate()
     }
   }
+  webview.bind("reportTestFailure", fn(id, req) {
+    let request_id = @ffi.from_cstr(id)
+    match decode_single_string_argument(req) {
+      Ok(message) => js_error = Some(message)
+      Err(message) =>
+        js_error = Some("Failed to decode JS failure payload: " + message)
+    }
+    webview.response(request_id, 0, "null")
+    webview.terminate()
+  })
   bridge.handle("ping", fn(payload : PingPayload) {
     seen_ping = Some(payload)
     bridge.send("nativeEvent", expected_event)
@@ -104,6 +137,14 @@ test "Command bridge exchanges typed commands with JavaScript" {
       #| <html>
       #|   <body>
       #|     <script>
+      #|       const reportFailure = (message) =>
+      #|         window.reportTestFailure(message).catch(() => {});
+      #|       window.addEventListener("error", (event) => {
+      #|         void reportFailure("window error: " + String(event.message));
+      #|       });
+      #|       window.addEventListener("unhandledrejection", (event) => {
+      #|         void reportFailure("unhandled rejection: " + String(event.reason));
+      #|       });
       #|       window.addEventListener("load", () => {
       #|         const bridge = window.MoonBitBridge;
       #|         bridge.onCommand((command) => {
@@ -111,7 +152,7 @@ test "Command bridge exchanges typed commands with JavaScript" {
       #|             bridge
       #|               .send("jsObservedNativeEvent", command.payload)
       #|               .catch((error) => {
-      #|                 document.body.textContent = "nativeEvent error: " + String(error);
+      #|                 return reportFailure("nativeEvent error: " + String(error));
       #|               });
       #|           }
       #|         });
@@ -119,7 +160,7 @@ test "Command bridge exchanges typed commands with JavaScript" {
       #|           .send("ping", { message: "hello from js", count: 3 })
       #|           .then((result) => bridge.send("jsResult", result))
       #|           .catch((error) => {
-      #|             document.body.textContent = "ping error: " + String(error);
+      #|             return reportFailure("ping error: " + String(error));
       #|           });
       #|       });
       #|     </script>
@@ -131,4 +172,42 @@ test "Command bridge exchanges typed commands with JavaScript" {
   assert_eq(seen_ping, Some(expected_ping))
   assert_eq(seen_reply, Some(expected_reply))
   assert_eq(seen_event, Some(expected_event))
+  assert_eq(js_error, None)
+}
+
+///|
+test "Command bridge rejects unknown commands with JSON string errors" {
+  let mut seen_error : String? = None
+  let webview = @webview.Webview::new()
+  let _bridge = @webview.CommandBridge::new(webview)
+  webview.bind("reportUnknownCommandError", fn(id, req) {
+    let request_id = @ffi.from_cstr(id)
+    match decode_single_string_argument(req) {
+      Ok(message) => seen_error = Some(message)
+      Err(message) =>
+        seen_error = Some("Failed to decode unknown-command payload: " + message)
+    }
+    webview.response(request_id, 0, "null")
+    webview.terminate()
+  })
+  webview.set_html(
+    (
+      #| <html>
+      #|   <body>
+      #|     <script>
+      #|       window.addEventListener("load", () => {
+      #|         const reportResult = (message) =>
+      #|           window.reportUnknownCommandError(message).catch(() => {});
+      #|         window.MoonBitBridge
+      #|           .send("missing", { ok: true })
+      #|           .then(() => reportResult("unexpected success"))
+      #|           .catch((error) => reportResult(String(error)));
+      #|       });
+      #|     </script>
+      #|   </body>
+      #| </html>,
+    ),
+  )
+  webview.run()
+  assert_eq(seen_error, Some("Unknown command: missing"))
 }

--- a/test/webview_test.mbt
+++ b/test/webview_test.mbt
@@ -1,3 +1,18 @@
+struct PingPayload {
+  message : String
+  count : Int
+} derive(ToJson, FromJson, Eq, Show)
+
+struct PingReply {
+  echoed : String
+  next_count : Int
+} derive(ToJson, FromJson, Eq, Show)
+
+struct NativeEvent {
+  label : String
+  total : Int
+} derive(ToJson, FromJson, Eq, Show)
+
 ///|
 test "Start app loop and terminate it" {
   let webview = @webview.Webview::new()
@@ -51,4 +66,69 @@ test "Bind callback marshals C strings safely" {
   assert_true(called)
   assert_true(!callback_id.is_empty())
   assert_eq(callback_req, "[\"hello\",123]")
+}
+
+///|
+test "Command bridge exchanges typed commands with JavaScript" {
+  let expected_ping = PingPayload::{ message: "hello from js", count: 3 }
+  let expected_reply = PingReply::{
+    echoed: "hello from js / handled by MoonBit",
+    next_count: 4,
+  }
+  let expected_event = NativeEvent::{ label: "native-ready", total: 6 }
+  let mut seen_ping : PingPayload? = None
+  let mut seen_reply : PingReply? = None
+  let mut seen_event : NativeEvent? = None
+  let webview = @webview.Webview::new()
+  let bridge = @webview.CommandBridge::new(webview)
+  let finish = fn() {
+    if seen_reply is Some(_) && seen_event is Some(_) {
+      webview.terminate()
+    }
+  }
+  bridge.handle("ping", fn(payload : PingPayload) {
+    seen_ping = Some(payload)
+    bridge.send("nativeEvent", expected_event)
+    expected_reply
+  })
+  bridge.handle("jsResult", fn(payload : PingReply) {
+    seen_reply = Some(payload)
+    finish()
+  })
+  bridge.handle("jsObservedNativeEvent", fn(payload : NativeEvent) {
+    seen_event = Some(payload)
+    finish()
+  })
+  webview.set_html(
+    (
+      #| <html>
+      #|   <body>
+      #|     <script>
+      #|       window.addEventListener("load", () => {
+      #|         const bridge = window.MoonBitBridge;
+      #|         bridge.onCommand((command) => {
+      #|           if (command.name === "nativeEvent") {
+      #|             bridge
+      #|               .send("jsObservedNativeEvent", command.payload)
+      #|               .catch((error) => {
+      #|                 document.body.textContent = "nativeEvent error: " + String(error);
+      #|               });
+      #|           }
+      #|         });
+      #|         bridge
+      #|           .send("ping", { message: "hello from js", count: 3 })
+      #|           .then((result) => bridge.send("jsResult", result))
+      #|           .catch((error) => {
+      #|             document.body.textContent = "ping error: " + String(error);
+      #|           });
+      #|       });
+      #|     </script>
+      #|   </body>
+      #| </html>,
+    ),
+  )
+  webview.run()
+  assert_eq(seen_ping, Some(expected_ping))
+  assert_eq(seen_reply, Some(expected_reply))
+  assert_eq(seen_event, Some(expected_event))
 }

--- a/test/webview_test.mbt
+++ b/test/webview_test.mbt
@@ -253,3 +253,18 @@ test "Command bridge returns structured errors for unknown commands" {
   webview.run()
   assert_eq(seen_response, Some(expected_response))
 }
+
+///|
+test "panic CommandBridge::new rejects duplicate binding names" {
+  let webview = @webview.Webview::new()
+  let _first = @webview.CommandBridge::new(webview)
+  let _second = @webview.CommandBridge::new(webview)
+}
+
+///|
+test "CommandBridge::destroy unbinds the internal binding" {
+  let webview = @webview.Webview::new()
+  let first = @webview.CommandBridge::new(webview)
+  first.destroy()
+  let _second = @webview.CommandBridge::new(webview)
+}


### PR DESCRIPTION
## Summary
This PR adds an explicit two-way command bridge between webview JavaScript and MoonBit, standardizes JS -> MoonBit replies as structured `CommandResponse` envelopes, and hardens the bridge lifecycle/configuration.

- JS -> MoonBit: `window.MoonBitBridge.send(name, payload)` invokes `CommandBridge::handle(...)` / `CommandBridge::handle_result(...)` and resolves a `Promise<CommandResponse>`.
- MoonBit -> JS: `bridge.send(name, payload)` dispatches a command into the page, and JavaScript receives it through `window.MoonBitBridge.onCommand(listener)`.
- Lifecycle/config hardening: `CommandBridge::new(...)` aborts on duplicate internal binding names, and `CommandBridge::destroy()` unbinds the internal bridge binding so the same `binding_name` can be reused on the same `Webview`.

## API shape
### MoonBit side
- `Command { name, payload }` is the message shape used in both directions
- `CommandResponse { status, payload, error }` wraps JS -> MoonBit replies
- `CommandBridge::new(...)` installs the bridge into a `Webview` and requires a unique `binding_name` per `Webview`
- `CommandBridge::handle(...)` registers typed success-path handlers
- `CommandBridge::handle_result(...)` registers typed handlers that can explicitly return `Result[Reply, String]`
- `CommandBridge::send(...)` remains fire-and-forget for MoonBit -> JS notifications
- `CommandBridge::destroy(...)` clears handlers and unbinds the bridge's internal JS -> MoonBit binding without destroying the underlying `Webview`
- `CommandResponse::ok(...)`, `CommandResponse::error(...)`, and `CommandResponse::is_ok(...)` provide helpers for structured replies

### JavaScript side
- `window.MoonBitBridge.send(name, payload)` returns `Promise<CommandResponse>`
- `window.MoonBitBridge.onCommand(listener)` receives MoonBit -> JS commands as `{ name, payload }`
- JavaScript callers inspect `response.status`, then read `response.payload` or `response.error`

## Changes
- add high-level `Command` and `CommandBridge` APIs on top of the existing bind/eval primitives
- add public `CommandResponse` helpers and expose them in `pkg.generated.mbti`
- add `CommandBridge::handle_result(...)` for explicit command-level errors
- route MoonBit -> JS dispatch through `webview.dispatch(...)` for UI-thread-safe delivery
- change the JS helper so `window.MoonBitBridge.send(...)` resolves structured `CommandResponse` objects
- make `CommandBridge::new(...)` fail fast on duplicate internal binding names
- add `CommandBridge::destroy(...)` so callers can explicitly unbind the internal bridge binding and reuse the same `binding_name`
- update the README, inline documentation comments, and `examples/16_command` to describe both directions and the lifecycle behavior
- extend bridge coverage in `test/webview_test.mbt` to assert structured success/error responses, duplicate-binding rejection, and destroy/rebind behavior
- switch CI test invocation from `moon --manifest-path ...` to `moon -C test ...` so the repository consistently uses directory-based Moon commands

## Verification
- `moon fmt --check`
- `moon check --target native --deny-warn`
- `moon -C examples/16_command check --target native`
- `moon -C test check --target native`
- `DYLD_LIBRARY_PATH=lib moon test --target native --doc`
- `DYLD_LIBRARY_PATH=lib moon -C examples build --target native`
