### PR TITLE
feat: add installable MoonBit plugins for webview apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,6 +203,8 @@ For module-level JS APIs, build on top of `CommandBridge` with `PluginHost`.
 - JavaScript calls the installed API through
   `window.MoonBitPlugins.<plugin>.<api>(payload)` or
   `window.MoonBitPlugins["@@call"](plugin, api, payload)`.
+- Plugin JS calls resolve to the same `CommandResponse` shape returned by
+  `CommandBridge.send(...)`, with `status`, `payload`, and `error`.
 - JavaScript subscribes to plugin events through
   `window.MoonBitPlugins.<plugin>["@@on"](listener)` or
   `window.MoonBitPlugins.<plugin>["@@onEvent"](name, listener)`.
@@ -255,7 +257,13 @@ fn main {
     #|   });
     #|   window.MoonBitPlugins.math
     #|     .sum({ left: 20, right: 22 })
-    #|     .then((response) => console.log(response))
+    #|     .then((response) => {
+    #|       if (response.status === "ok") {
+    #|         console.log("plugin payload", response.payload);
+    #|         return;
+    #|       }
+    #|       console.error("plugin error", response.error);
+    #|     })
     #|     .catch(console.error);
     #| </script>,
   )
@@ -272,8 +280,10 @@ Notes:
   normal application shutdown.
 - Install a plugin before loading content if you want the JS API to exist on the
   first page load.
-- Plugin names starting with `@@` are reserved for framework/internal use.
-- Plugin API names starting with `@@` are reserved for framework/internal use.
+- Plugin names and API names starting with `@@` are reserved for
+  framework/internal use.
+- Special JavaScript property names such as `__proto__`, `prototype`, and
+  `constructor` are also reserved for plugin names and API names.
 - The JS host uses reserved helper keys `@@call`, `@@has`, `@@ensurePlugin`,
   `@@defineApi`, `@@on`, `@@onEvent`, and `@@emit`.
 - Duplicate plugin names or duplicate APIs inside the same plugin abort during

--- a/README.md
+++ b/README.md
@@ -193,6 +193,92 @@ fn main {
 }
 ```
 
+## Plugin System
+
+For module-level JS APIs, build on top of `CommandBridge` with `PluginHost`.
+
+- A MoonBit module exports a `Plugin`.
+- The main program installs that plugin on a `PluginHost`.
+- Plugins can define native install/destroy hooks.
+- JavaScript calls the installed API through
+  `window.MoonBitPlugins.<plugin>.<api>(payload)` or
+  `window.MoonBitPlugins["@@call"](plugin, api, payload)`.
+- JavaScript subscribes to plugin events through
+  `window.MoonBitPlugins.<plugin>["@@on"](listener)` or
+  `window.MoonBitPlugins.<plugin>["@@onEvent"](name, listener)`.
+
+```moonbit
+struct SumPayload {
+  left : Int
+  right : Int
+} derive(ToJson, FromJson)
+
+struct SumReply {
+  total : Int
+} derive(ToJson, FromJson)
+
+struct NoticePayload {
+  message : String
+} derive(ToJson, FromJson)
+
+pub fn math_plugin() -> @webview.Plugin {
+  @webview.Plugin::new(
+    "math",
+    fn(plugin) {
+      plugin.command("sum", fn(payload : SumPayload) {
+        let reply = SumReply::{ total: payload.left + payload.right }
+        plugin.emit("computed", NoticePayload::{
+          message: "MoonBit computed " + reply.total.to_string(),
+        })
+        reply
+      })
+    },
+    on_install=fn(plugin) {
+      // Native setup can happen here.
+      let _ = plugin.name()
+    },
+    on_destroy=fn(plugin) {
+      // Native cleanup can happen here.
+      let _ = plugin.name()
+    },
+  )
+}
+
+fn main {
+  let webview = @webview.Webview::new(debug=1)
+  let plugins = @webview.PluginHost::new(webview)
+  plugins.install(math_plugin())
+  webview.set_html(
+    #| <script>
+    #|   window.MoonBitPlugins.math["@@onEvent"]("computed", (event) => {
+    #|     console.log("plugin event", event);
+    #|   });
+    #|   window.MoonBitPlugins.math
+    #|     .sum({ left: 20, right: 22 })
+    #|     .then((response) => console.log(response))
+    #|     .catch(console.error);
+    #| </script>,
+  )
+  plugins.run()
+}
+```
+
+Notes:
+- `PluginHost` uses `CommandBridge` internally; access it with
+  `plugins.command_bridge()` if you need lower-level command registration too.
+- Use `plugins.emit(plugin, name, payload)` when the main program, rather than a
+  plugin context, needs to push a plugin-scoped event into JavaScript.
+- Use `plugins.run()` when you need plugin `on_destroy` hooks to run as part of
+  normal application shutdown.
+- Install a plugin before loading content if you want the JS API to exist on the
+  first page load.
+- Plugin names starting with `@@` are reserved for framework/internal use.
+- Plugin API names starting with `@@` are reserved for framework/internal use.
+- The JS host uses reserved helper keys `@@call`, `@@has`, `@@ensurePlugin`,
+  `@@defineApi`, `@@on`, `@@onEvent`, and `@@emit`.
+- Duplicate plugin names or duplicate APIs inside the same plugin abort during
+  installation.
+
 ## 📚 Examples
 
 This repository includes several examples in the `examples/` directory:
@@ -213,6 +299,7 @@ This repository includes several examples in the `examples/` directory:
 - **14_beforeunload** - Handling window close events
 - **15_close** - Window close management
 - **16_command** - Structured JS <-> MoonBit command bridge
+- **17_plugin** - Plugin modules exposed as JavaScript APIs
 
 Run any example:
 

--- a/examples/17_plugin/main.mbt
+++ b/examples/17_plugin/main.mbt
@@ -1,0 +1,82 @@
+///|
+let html =
+  #| <html>
+  #|   <head>
+  #|     <style>
+  #|       body {
+  #|         margin: 0;
+  #|         min-height: 100vh;
+  #|         display: grid;
+  #|         place-items: center;
+  #|         background:
+  #|           radial-gradient(circle at top, #f7f1d9 0%, transparent 42%),
+  #|           linear-gradient(160deg, #dce9f4 0%, #f6efe4 100%);
+  #|         color: #14212b;
+  #|         font-family: "Avenir Next", "Gill Sans", sans-serif;
+  #|       }
+  #|       main {
+  #|         width: min(34rem, calc(100vw - 3rem));
+  #|         padding: 2rem;
+  #|         border-radius: 22px;
+  #|         background: rgba(255, 255, 255, 0.84);
+  #|         box-shadow: 0 24px 70px rgba(20, 33, 43, 0.14);
+  #|       }
+  #|       button {
+  #|         border: 0;
+  #|         border-radius: 999px;
+  #|         padding: 0.85rem 1.2rem;
+  #|         background: #14212b;
+  #|         color: white;
+  #|         font: inherit;
+  #|         cursor: pointer;
+  #|       }
+  #|       pre {
+  #|         margin-top: 1rem;
+  #|         padding: 1rem;
+  #|         border-radius: 14px;
+  #|         background: #eef3f7;
+  #|         white-space: pre-wrap;
+  #|       }
+  #|     </style>
+  #|   </head>
+  #|   <body>
+  #|     <main>
+  #|       <h1>Plugin Host</h1>
+  #|       <p>A MoonBit plugin module installs a namespaced JS API and event stream on <code>window.MoonBitPlugins</code>.</p>
+  #|       <button id="run">Call math.sum</button>
+  #|       <pre id="output">Click the button.</pre>
+  #|     </main>
+  #|     <script>
+  #|       const output = document.getElementById("output");
+  #|       let lastEvent = null;
+  #|       window.MoonBitPlugins.math["@@onEvent"]("computed", (event) => {
+  #|         lastEvent = event;
+  #|         output.textContent =
+  #|           "Plugin event:\n" + JSON.stringify(event, null, 2);
+  #|       });
+  #|       document.getElementById("run").addEventListener("click", () => {
+  #|         window.MoonBitPlugins.math
+  #|           .sum({ left: 20, right: 22 })
+  #|           .then((response) => {
+  #|             output.textContent =
+  #|               "Plugin response:\n" + JSON.stringify(response, null, 2) +
+  #|               "\n\nLast event:\n" + JSON.stringify(lastEvent, null, 2);
+  #|           })
+  #|           .catch((error) => {
+  #|             output.textContent = "Transport error:\n" + String(error);
+  #|           });
+  #|       });
+  #|     </script>
+  #|   </body>
+  #| </html>
+
+///|
+fn main {
+  let webview = @webview.Webview::new(debug=1)
+  let plugins = @webview.PluginHost::new(webview)
+  plugins.install(plugin())
+  webview.set_title("MoonBit Plugin Host")
+  webview.set_size(900, 640, @webview.SizeHint::None)
+  webview.set_html(html)
+  plugins.run()
+}

--- a/examples/17_plugin/main.mbt
+++ b/examples/17_plugin/main.mbt
@@ -42,7 +42,7 @@ let html =
   #|   <body>
   #|     <main>
   #|       <h1>Plugin Host</h1>
-  #|       <p>A MoonBit plugin module installs a namespaced JS API and event stream on <code>window.MoonBitPlugins</code>.</p>
+  #|       <p>A MoonBit plugin module installs a namespaced JS API and event stream on <code>window.MoonBitPlugins</code>, and each call returns a structured <code>CommandResponse</code>.</p>
   #|       <button id="run">Call math.sum</button>
   #|       <pre id="output">Click the button.</pre>
   #|     </main>
@@ -58,9 +58,14 @@ let html =
   #|         window.MoonBitPlugins.math
   #|           .sum({ left: 20, right: 22 })
   #|           .then((response) => {
+  #|             if (response.status === "ok") {
+  #|               output.textContent =
+  #|                 "Plugin payload:\n" + JSON.stringify(response.payload, null, 2) +
+  #|                 "\n\nLast event:\n" + JSON.stringify(lastEvent, null, 2);
+  #|               return;
+  #|             }
   #|             output.textContent =
-  #|               "Plugin response:\n" + JSON.stringify(response, null, 2) +
-  #|               "\n\nLast event:\n" + JSON.stringify(lastEvent, null, 2);
+  #|               "Plugin error:\n" + JSON.stringify(response, null, 2);
   #|           })
   #|           .catch((error) => {
   #|             output.textContent = "Transport error:\n" + String(error);

--- a/examples/17_plugin/math_plugin.mbt
+++ b/examples/17_plugin/math_plugin.mbt
@@ -1,0 +1,28 @@
+///|
+struct SumPayload {
+  left : Int
+  right : Int
+} derive(ToJson, FromJson, Eq, Show)
+
+///|
+struct SumReply {
+  total : Int
+} derive(ToJson, FromJson, Eq, Show)
+
+///|
+struct ComputedNotice {
+  message : String
+} derive(ToJson, FromJson, Eq, Show)
+
+///|
+pub fn plugin() -> @webview.Plugin {
+  @webview.Plugin::new("math", fn(plugin) {
+    plugin.command("sum", fn(payload : SumPayload) {
+      let reply = SumReply::{ total: payload.left + payload.right }
+      plugin.emit("computed", ComputedNotice::{
+        message: "MoonBit computed " + reply.total.to_string(),
+      })
+      reply
+    })
+  })
+}

--- a/examples/17_plugin/moon.pkg
+++ b/examples/17_plugin/moon.pkg
@@ -1,0 +1,16 @@
+import {
+  "moonbitlang/core/json",
+  "justjavac/webview",
+}
+
+options(
+  "is-main": true,
+  link: {
+    "native": {
+      "cc-flags": "-fwrapv -fsanitize=address -fsanitize=undefined",
+      "cc-link-flags": "-L../lib -lwebview",
+    },
+  },
+  "supported-targets": [ "native" ],
+  targets: { "main.mbt": [ "native" ] },
+)

--- a/examples/Readme.md
+++ b/examples/Readme.md
@@ -16,3 +16,4 @@
 | 12_embed        | ✓      |                                         |
 | 13_todo         | ✓      |                                         |
 | 16_command      | ✓      | Structured JS <-> MoonBit bridge       |
+| 17_plugin       | ✓      | Plugin modules exposed as JS APIs      |

--- a/src/moon.pkg
+++ b/src/moon.pkg
@@ -15,6 +15,7 @@ options(
   targets: {
     "binding.mbt": [ "native" ],
     "command.mbt": [ "native" ],
+    "plugin.mbt": [ "native" ],
     "webview.mbt": [ "native" ],
   },
 )

--- a/src/pkg.generated.mbti
+++ b/src/pkg.generated.mbti
@@ -78,6 +78,34 @@ pub impl Show for CommandResponse
 pub impl ToJson for CommandResponse
 pub impl @json.FromJson for CommandResponse
 
+pub struct PluginEvent {
+  plugin : String
+  name : String
+  payload : Json
+}
+pub impl Eq for PluginEvent
+pub impl Show for PluginEvent
+pub impl ToJson for PluginEvent
+pub impl @json.FromJson for PluginEvent
+
+type Plugin
+pub fn Plugin::new(String, (PluginContext) -> Unit, on_install? : (PluginContext) -> Unit, on_destroy? : (PluginContext) -> Unit) -> Self
+
+type PluginContext
+pub fn[Payload : @json.FromJson, Reply : ToJson] PluginContext::command(Self, String, (Payload) -> Reply) -> Unit
+pub fn[Payload : @json.FromJson, Reply : ToJson] PluginContext::command_result(Self, String, (Payload) -> Result[Reply, String]) -> Unit
+pub fn[Payload : ToJson] PluginContext::emit(Self, String, Payload) -> Unit
+pub fn PluginContext::name(Self) -> String
+
+type PluginHost
+pub fn PluginHost::command_bridge(Self) -> CommandBridge
+pub fn PluginHost::destroy(Self) -> Unit
+pub fn[Payload : ToJson] PluginHost::emit(Self, String, String, Payload) -> Unit
+pub fn PluginHost::global_name(Self) -> String
+pub fn PluginHost::install(Self, Plugin) -> Unit
+pub fn PluginHost::new(Webview, global_name? : String, command_global_name? : String, binding_name? : String, event_name? : String) -> Self
+pub fn PluginHost::run(Self) -> Unit
+
 pub(all) enum NativeHandleKind {
   Window
   Widget
@@ -118,4 +146,3 @@ pub type Webview_t
 // Type aliases
 
 // Traits
-

--- a/src/plugin.mbt
+++ b/src/plugin.mbt
@@ -288,13 +288,21 @@ fn plugin_event_command_name() -> String {
 }
 
 ///|
+fn is_disallowed_js_property_name(name : String) -> Bool {
+  name.has_prefix("@@") ||
+  name == "__proto__" ||
+  name == "prototype" ||
+  name == "constructor"
+}
+
+///|
 fn is_reserved_plugin_name(plugin_name : String) -> Bool {
-  plugin_name.has_prefix("@@")
+  is_disallowed_js_property_name(plugin_name)
 }
 
 ///|
 fn is_reserved_api_name(api_name : String) -> Bool {
-  api_name.has_prefix("@@")
+  is_disallowed_js_property_name(api_name)
 }
 
 ///|
@@ -338,6 +346,9 @@ fn make_plugin_host_script(
   "    }" +
   "    if (typeof plugin['@@onEvent'] !== 'function') {" +
   "      plugin['@@onEvent'] = function(eventName, listener) {" +
+  "        if (typeof listener !== 'function') {" +
+  "          throw new TypeError('MoonBit plugin listener must be a function');" +
+  "        }" +
   "        return plugin['@@on'](function(event) {" +
   "          if (event.name === eventName) {" +
   "            listener(event);" +

--- a/src/plugin.mbt
+++ b/src/plugin.mbt
@@ -1,0 +1,496 @@
+///|
+/// A plugin definition that can be installed into a `PluginHost`.
+///
+/// A plugin is typically exposed from a MoonBit module:
+///
+/// ```moonbit nocheck
+/// pub fn plugin() -> @webview.Plugin {
+///   @webview.Plugin::new("math", fn(plugin) {
+///     plugin.command("sum", fn(payload : SumPayload) {
+///       SumReply::{ total: payload.left + payload.right }
+///     })
+///   })
+/// }
+/// ```
+///
+/// `on_install` runs after the plugin has finished registering commands and
+/// JS helpers on the host. `on_destroy` runs when `PluginHost::destroy()` is
+/// called, before the underlying `CommandBridge` is torn down.
+struct Plugin {
+  name : String
+  register : (PluginContext) -> Unit
+  on_install : (PluginContext) -> Unit
+  on_destroy : (PluginContext) -> Unit
+}
+
+///|
+/// Installs MoonBit plugins into a `Webview` and exposes them as JavaScript
+/// APIs through the existing `CommandBridge`.
+///
+/// On the JavaScript side this exposes:
+/// - `window[global_name]["@@call"](plugin_name, api_name, payload)`
+/// - `window[global_name][plugin_name][api_name](payload)`
+/// - `window[global_name][plugin_name]["@@on"](listener)`
+/// - `window[global_name][plugin_name]["@@onEvent"](name, listener)`
+///
+/// These JS APIs forward to MoonBit through `CommandBridge::handle(...)`.
+/// Plugin events are forwarded from MoonBit to JavaScript through the same
+/// bridge and delivered as `PluginEvent`.
+struct PluginHost {
+  webview : Webview
+  bridge : CommandBridge
+  global_name : String
+  plugins : Map[String, Bool]
+  apis : Map[String, Bool]
+  destroy_hooks : Map[String, () -> Unit]
+}
+
+///|
+/// Registration context handed to a plugin while it installs its public APIs.
+struct PluginContext {
+  host : PluginHost
+  plugin_name : String
+}
+
+///|
+/// A plugin-scoped event sent from MoonBit to JavaScript.
+pub struct PluginEvent {
+  plugin : String
+  name : String
+  payload : Json
+} derive(ToJson, FromJson, Show, Eq)
+
+///|
+/// Builds a plugin value that can later be installed on a `PluginHost`.
+pub fn Plugin::new(
+  name : String,
+  register : (PluginContext) -> Unit,
+  on_install? : (PluginContext) -> Unit = fn(_context) {  },
+  on_destroy? : (PluginContext) -> Unit = fn(_context) {  },
+) -> Plugin {
+  Plugin::{ name, register, on_install, on_destroy }
+}
+
+///|
+/// Creates a plugin host backed by a `CommandBridge`.
+///
+/// `global_name` controls the JavaScript namespace used for plugin APIs and
+/// defaults to `window.MoonBitPlugins`.
+///
+/// `command_global_name`, `binding_name`, and `event_name` are passed through
+/// to the underlying `CommandBridge`.
+pub fn PluginHost::new(
+  webview : Webview,
+  global_name? : String = "MoonBitPlugins",
+  command_global_name? : String = "MoonBitBridge",
+  binding_name? : String = "__moonbit_command",
+  event_name? : String = "moonbit:command",
+) -> PluginHost {
+  let host = PluginHost::{
+    webview,
+    bridge: CommandBridge::new(
+      webview,
+      global_name=command_global_name,
+      binding_name~,
+      event_name~,
+    ),
+    global_name,
+    plugins: {},
+    apis: {},
+    destroy_hooks: {},
+  }
+  host.install_script(make_plugin_host_script(global_name, command_global_name))
+  host
+}
+
+///|
+/// Returns the JavaScript global object name used for plugin APIs.
+pub fn PluginHost::global_name(self : PluginHost) -> String {
+  self.global_name
+}
+
+///|
+/// Returns the underlying command bridge used by the plugin host.
+pub fn PluginHost::command_bridge(self : PluginHost) -> CommandBridge {
+  self.bridge
+}
+
+///|
+/// Installs a plugin into the host.
+///
+/// This aborts if another plugin with the same name has already been
+/// installed on this host.
+pub fn PluginHost::install(self : PluginHost, plugin : Plugin) -> Unit {
+  guard !is_reserved_plugin_name(plugin.name) else {
+    abort("PluginHost::install: reserved plugin name: " + plugin.name)
+  }
+  guard self.plugins.get(plugin.name) is None else {
+    abort("PluginHost::install: plugin already installed: " + plugin.name)
+  }
+  let context = PluginContext::{ host: self, plugin_name: plugin.name }
+  self.plugins.set(plugin.name, true)
+  self.destroy_hooks.set(plugin.name, fn() { (plugin.on_destroy)(context) })
+  self.install_script(
+    make_plugin_namespace_script(self.global_name, plugin.name),
+  )
+  (plugin.register)(context)
+  (plugin.on_install)(context)
+}
+
+///|
+/// Drops all registered plugin metadata and destroys the underlying
+/// `CommandBridge`.
+pub fn PluginHost::destroy(self : PluginHost) -> Unit {
+  for _, hook in self.destroy_hooks {
+    hook()
+  }
+  self.plugins.clear()
+  self.apis.clear()
+  self.destroy_hooks.clear()
+  self.bridge.destroy()
+}
+
+///|
+/// Runs the underlying webview loop and then tears the plugin host down in the
+/// correct order so destroy hooks run before the native webview is destroyed.
+pub fn PluginHost::run(self : PluginHost) -> Unit {
+  let _ = webview_run(self.webview.get_handle())
+  self.destroy()
+  self.webview.destroy()
+}
+
+///|
+/// Returns the plugin name currently being installed.
+pub fn PluginContext::name(self : PluginContext) -> String {
+  self.plugin_name
+}
+
+///|
+/// Emits a plugin-scoped event from the main program to JavaScript.
+///
+/// JavaScript receives these events through
+/// `window.MoonBitPlugins[plugin_name]["@@on"](...)` and
+/// `window.MoonBitPlugins[plugin_name]["@@onEvent"](...)`.
+pub fn[Payload : ToJson] PluginHost::emit(
+  self : PluginHost,
+  plugin_name : String,
+  event_name : String,
+  payload : Payload,
+) -> Unit {
+  guard self.plugins.get(plugin_name) is Some(_) else {
+    abort("PluginHost::emit: plugin is not installed: " + plugin_name)
+  }
+  self.bridge.send(plugin_event_command_name(), PluginEvent::{
+    plugin: plugin_name,
+    name: event_name,
+    payload: ToJson::to_json(payload),
+  })
+}
+
+///|
+/// Emits a plugin-scoped event to JavaScript.
+///
+/// This is safe to call from command handlers or lifecycle hooks.
+pub fn[Payload : ToJson] PluginContext::emit(
+  self : PluginContext,
+  event_name : String,
+  payload : Payload,
+) -> Unit {
+  self.host.emit(self.plugin_name, event_name, payload)
+}
+
+///|
+/// Registers a typed plugin command.
+///
+/// The command becomes callable from JavaScript through:
+/// `window.MoonBitPlugins[plugin_name][api_name](payload)`.
+pub fn[Payload : @json.FromJson, Reply : ToJson] PluginContext::command(
+  self : PluginContext,
+  api_name : String,
+  callback : (Payload) -> Reply,
+) -> Unit {
+  let command_name = self.register_api(api_name)
+  self.host.bridge.handle(command_name, callback)
+  self.host.install_script(
+    make_plugin_api_script(
+      self.host.global_name,
+      self.host.bridge.global_name(),
+      self.plugin_name,
+      api_name,
+      command_name,
+    ),
+  )
+}
+
+///|
+/// Registers a typed plugin command that can return explicit command errors.
+pub fn[Payload : @json.FromJson, Reply : ToJson] PluginContext::command_result(
+  self : PluginContext,
+  api_name : String,
+  callback : (Payload) -> Result[Reply, String],
+) -> Unit {
+  let command_name = self.register_api(api_name)
+  self.host.bridge.handle_result(command_name, callback)
+  self.host.install_script(
+    make_plugin_api_script(
+      self.host.global_name,
+      self.host.bridge.global_name(),
+      self.plugin_name,
+      api_name,
+      command_name,
+    ),
+  )
+}
+
+///|
+fn PluginContext::register_api(
+  self : PluginContext,
+  api_name : String,
+) -> String {
+  guard !is_reserved_api_name(api_name) else {
+    abort(
+      "PluginContext::register_api: reserved API name: " +
+      self.plugin_name +
+      "." +
+      api_name,
+    )
+  }
+  let command_name = plugin_command_name(self.plugin_name, api_name)
+  guard self.host.apis.get(command_name) is None else {
+    abort(
+      "PluginContext::register_api: API already registered: " +
+      self.plugin_name +
+      "." +
+      api_name,
+    )
+  }
+  self.host.apis.set(command_name, true)
+  command_name
+}
+
+///|
+fn PluginHost::install_script(self : PluginHost, script : String) -> Unit {
+  self.webview.init(script)
+  self.webview.dispatch(fn() { self.webview.eval(script) })
+}
+
+///|
+fn plugin_command_name(plugin_name : String, api_name : String) -> String {
+  "plugin:" +
+  Json::string(plugin_name).stringify() +
+  ":" +
+  Json::string(api_name).stringify()
+}
+
+///|
+fn plugin_event_command_name() -> String {
+  "@@plugin:event"
+}
+
+///|
+fn is_reserved_plugin_name(plugin_name : String) -> Bool {
+  plugin_name.has_prefix("@@")
+}
+
+///|
+fn is_reserved_api_name(api_name : String) -> Bool {
+  api_name.has_prefix("@@")
+}
+
+///|
+fn make_plugin_host_script(
+  global_name : String,
+  bridge_global_name : String,
+) -> String {
+  let global_name_js = Json::string(global_name).stringify()
+  let bridge_global_name_js = Json::string(bridge_global_name).stringify()
+  "(function() {" +
+  "  const globalName = " +
+  global_name_js +
+  ";" +
+  "  const bridgeName = " +
+  bridge_global_name_js +
+  ";" +
+  "  const pluginEventCommand = '@@plugin:event';" +
+  "  const existing = window[globalName];" +
+  "  const root = existing && typeof existing === 'object' ? existing : Object.create(null);" +
+  "  function getBridge() {" +
+  "    const bridge = window[bridgeName];" +
+  "    return bridge && typeof bridge.send === 'function' ? bridge : null;" +
+  "  }" +
+  "  function ensurePluginHelpers(plugin) {" +
+  "    if (!Array.isArray(plugin['@@listeners'])) {" +
+  "      plugin['@@listeners'] = [];" +
+  "    }" +
+  "    if (typeof plugin['@@on'] !== 'function') {" +
+  "      plugin['@@on'] = function(listener) {" +
+  "        root['@@ensureBridgeListener']();" +
+  "        if (typeof listener !== 'function') {" +
+  "          throw new TypeError('MoonBit plugin listener must be a function');" +
+  "        }" +
+  "        plugin['@@listeners'].push(listener);" +
+  "        return function() {" +
+  "          plugin['@@listeners'] = plugin['@@listeners'].filter(function(candidate) {" +
+  "            return candidate !== listener;" +
+  "          });" +
+  "        };" +
+  "      };" +
+  "    }" +
+  "    if (typeof plugin['@@onEvent'] !== 'function') {" +
+  "      plugin['@@onEvent'] = function(eventName, listener) {" +
+  "        return plugin['@@on'](function(event) {" +
+  "          if (event.name === eventName) {" +
+  "            listener(event);" +
+  "          }" +
+  "        });" +
+  "      };" +
+  "    }" +
+  "    return plugin;" +
+  "  }" +
+  "  root['@@call'] = function(pluginName, apiName, payload) {" +
+  "    root['@@ensureBridgeListener']();" +
+  "    const bridge = getBridge();" +
+  "    if (!bridge) {" +
+  "      return Promise.reject(new Error('MoonBit command bridge is not available'));" +
+  "    }" +
+  "    return bridge.send('plugin:' + JSON.stringify(pluginName) + ':' + JSON.stringify(apiName), payload);" +
+  "  };" +
+  "  root['@@ensurePlugin'] = function(pluginName) {" +
+  "    const plugin = root[pluginName];" +
+  "    if (plugin && typeof plugin === 'object') {" +
+  "      return ensurePluginHelpers(plugin);" +
+  "    }" +
+  "    const next = Object.create(null);" +
+  "    root[pluginName] = next;" +
+  "    return ensurePluginHelpers(next);" +
+  "  };" +
+  "  root['@@emit'] = function(pluginName, eventName, payload) {" +
+  "    const plugin = root['@@ensurePlugin'](pluginName);" +
+  "    const event = {" +
+  "      plugin: pluginName," +
+  "      name: eventName," +
+  "      payload: payload === undefined ? null : payload" +
+  "    };" +
+  "    const listeners = plugin['@@listeners'].slice();" +
+  "    for (const listener of listeners) {" +
+  "      listener(event);" +
+  "    }" +
+  "    return event;" +
+  "  };" +
+  "  root['@@ensureBridgeListener'] = function() {" +
+  "    if (root['@@bridgeListenerInstalled']) {" +
+  "      return true;" +
+  "    }" +
+  "    const bridge = getBridge();" +
+  "    if (!bridge || typeof bridge.onCommand !== 'function') {" +
+  "      return false;" +
+  "    }" +
+  "    bridge.onCommand(function(command) {" +
+  "      if (!command || command.name !== pluginEventCommand) {" +
+  "        return;" +
+  "      }" +
+  "      const event = command.payload;" +
+  "      if (!event || typeof event !== 'object') {" +
+  "        return;" +
+  "      }" +
+  "      root['@@emit'](event.plugin, event.name, event.payload);" +
+  "    });" +
+  "    root['@@bridgeListenerInstalled'] = true;" +
+  "    return true;" +
+  "  };" +
+  "  root['@@defineApi'] = function(pluginName, apiName, commandName) {" +
+  "    const plugin = root['@@ensurePlugin'](pluginName);" +
+  "    root['@@ensureBridgeListener']();" +
+  "    plugin[apiName] = function(payload) {" +
+  "      const bridge = getBridge();" +
+  "      if (!bridge) {" +
+  "        return Promise.reject(new Error('MoonBit command bridge is not available'));" +
+  "      }" +
+  "      return bridge.send(commandName, payload);" +
+  "    };" +
+  "    return plugin[apiName];" +
+  "  };" +
+  "  root['@@has'] = function(pluginName, apiName) {" +
+  "    const plugin = root[pluginName];" +
+  "    return !!(plugin && typeof plugin[apiName] === 'function');" +
+  "  };" +
+  "  root['@@ensureBridgeListener']();" +
+  "  window[globalName] = root;" +
+  "})();"
+}
+
+///|
+fn make_plugin_namespace_script(
+  global_name : String,
+  plugin_name : String,
+) -> String {
+  let global_name_js = Json::string(global_name).stringify()
+  let plugin_name_js = Json::string(plugin_name).stringify()
+  "(function() {" +
+  "  const globalName = " +
+  global_name_js +
+  ";" +
+  "  const pluginName = " +
+  plugin_name_js +
+  ";" +
+  "  const root = window[globalName] && typeof window[globalName] === 'object'" +
+  "    ? window[globalName]" +
+  "    : (window[globalName] = Object.create(null));" +
+  "  if (typeof root['@@ensurePlugin'] === 'function') {" +
+  "    root['@@ensurePlugin'](pluginName);" +
+  "    return;" +
+  "  }" +
+  "  if (!root[pluginName] || typeof root[pluginName] !== 'object') {" +
+  "    root[pluginName] = Object.create(null);" +
+  "  }" +
+  "})();"
+}
+
+///|
+fn make_plugin_api_script(
+  global_name : String,
+  bridge_global_name : String,
+  plugin_name : String,
+  api_name : String,
+  command_name : String,
+) -> String {
+  let global_name_js = Json::string(global_name).stringify()
+  let bridge_global_name_js = Json::string(bridge_global_name).stringify()
+  let plugin_name_js = Json::string(plugin_name).stringify()
+  let api_name_js = Json::string(api_name).stringify()
+  let command_name_js = Json::string(command_name).stringify()
+  "(function() {" +
+  "  const globalName = " +
+  global_name_js +
+  ";" +
+  "  const bridgeName = " +
+  bridge_global_name_js +
+  ";" +
+  "  const pluginName = " +
+  plugin_name_js +
+  ";" +
+  "  const apiName = " +
+  api_name_js +
+  ";" +
+  "  const commandName = " +
+  command_name_js +
+  ";" +
+  "  const root = window[globalName] && typeof window[globalName] === 'object'" +
+  "    ? window[globalName]" +
+  "    : (window[globalName] = Object.create(null));" +
+  "  if (typeof root['@@defineApi'] === 'function') {" +
+  "    root['@@defineApi'](pluginName, apiName, commandName);" +
+  "    return;" +
+  "  }" +
+  "  const plugin = root[pluginName] && typeof root[pluginName] === 'object'" +
+  "    ? root[pluginName]" +
+  "    : (root[pluginName] = Object.create(null));" +
+  "  plugin[apiName] = function(payload) {" +
+  "    const bridge = window[bridgeName];" +
+  "    if (!bridge || typeof bridge.send !== 'function') {" +
+  "      return Promise.reject(new Error('MoonBit command bridge is not available'));" +
+  "    }" +
+  "    return bridge.send(commandName, payload);" +
+  "  };" +
+  "})();"
+}

--- a/test/webview_test.mbt
+++ b/test/webview_test.mbt
@@ -422,6 +422,13 @@ test "panic PluginHost::install rejects reserved plugin names" {
 }
 
 ///|
+test "panic PluginHost::install rejects special JavaScript property names" {
+  let webview = @webview.Webview::new()
+  let plugins = @webview.PluginHost::new(webview)
+  plugins.install(@webview.Plugin::new("__proto__", fn(_plugin) {  }))
+}
+
+///|
 test "Plugin lifecycle hooks run on install and destroy" {
   let mut installed_plugin : String? = None
   let mut destroyed_plugin : String? = None
@@ -455,6 +462,17 @@ test "panic PluginContext::command rejects reserved API names" {
   plugins.install(
     @webview.Plugin::new("math", fn(plugin) {
       plugin.command("@@on", fn(payload : Json) { payload })
+    }),
+  )
+}
+
+///|
+test "panic PluginContext::command rejects special JavaScript property names" {
+  let webview = @webview.Webview::new()
+  let plugins = @webview.PluginHost::new(webview)
+  plugins.install(
+    @webview.Plugin::new("math", fn(plugin) {
+      plugin.command("constructor", fn(payload : Json) { payload })
     }),
   )
 }

--- a/test/webview_test.mbt
+++ b/test/webview_test.mbt
@@ -1,16 +1,42 @@
+///|
 struct PingPayload {
   message : String
   count : Int
 } derive(ToJson, FromJson, Eq, Show)
 
+///|
 struct PingReply {
   echoed : String
   next_count : Int
 } derive(ToJson, FromJson, Eq, Show)
 
+///|
 struct NativeEvent {
   label : String
   total : Int
+} derive(ToJson, FromJson, Eq, Show)
+
+///|
+struct MultiplyPayload {
+  left : Int
+  right : Int
+} derive(ToJson, FromJson, Eq, Show)
+
+///|
+struct MultiplyReply {
+  total : Int
+} derive(ToJson, FromJson, Eq, Show)
+
+///|
+struct PluginNotice {
+  message : String
+} derive(ToJson, FromJson, Eq, Show)
+
+///|
+struct PluginNoticeEvent {
+  plugin : String
+  name : String
+  payload : PluginNotice
 } derive(ToJson, FromJson, Eq, Show)
 
 ///|
@@ -125,8 +151,9 @@ test "Command bridge exchanges typed commands with JavaScript" {
   })
   webview.bind("reportPingResponse", fn(id, req) {
     let request_id = @ffi.from_cstr(id)
-    let response_result : Result[@webview.CommandResponse, String] =
-      decode_single_argument(req)
+    let response_result : Result[@webview.CommandResponse, String] = decode_single_argument(
+      req,
+    )
     match response_result {
       Ok(response) => {
         seen_response = Some(response)
@@ -212,17 +239,17 @@ test "Command bridge returns structured errors for unknown commands" {
   let _bridge = @webview.CommandBridge::new(webview)
   webview.bind("reportUnknownCommandError", fn(id, req) {
     let request_id = @ffi.from_cstr(id)
-    let response_result : Result[@webview.CommandResponse, String] =
-      decode_single_argument(req)
+    let response_result : Result[@webview.CommandResponse, String] = decode_single_argument(
+      req,
+    )
     match response_result {
       Ok(response) => seen_response = Some(response)
-      Err(message) => {
+      Err(message) =>
         seen_response = Some(
           @webview.CommandResponse::error(
             "Failed to decode unknown-command payload: " + message,
           ),
         )
-      }
     }
     webview.response(request_id, 0, "null")
     webview.terminate()
@@ -255,10 +282,193 @@ test "Command bridge returns structured errors for unknown commands" {
 }
 
 ///|
+test "Plugin host exposes plugin APIs into JavaScript" {
+  let expected_response = @webview.CommandResponse::ok(MultiplyReply::{
+    total: 42,
+  })
+  let expected_event = PluginNoticeEvent::{
+    plugin: "math",
+    name: "computed",
+    payload: PluginNotice::{ message: "MoonBit computed 42" },
+  }
+  let mut seen_response : @webview.CommandResponse? = None
+  let mut seen_event : PluginNoticeEvent? = None
+  let mut js_error : String? = None
+  let webview = @webview.Webview::new()
+  let plugins = @webview.PluginHost::new(webview)
+  let finish = fn() {
+    if seen_response is Some(_) && seen_event is Some(_) {
+      webview.terminate()
+    }
+  }
+  plugins.install(
+    @webview.Plugin::new("math", fn(plugin) {
+      plugin.command("multiply", fn(payload : MultiplyPayload) {
+        let reply = MultiplyReply::{ total: payload.left * payload.right }
+        plugin.emit("computed", PluginNotice::{
+          message: "MoonBit computed " + reply.total.to_string(),
+        })
+        reply
+      })
+    }),
+  )
+  webview.bind("reportPluginFailure", fn(id, req) {
+    let request_id = @ffi.from_cstr(id)
+    let message_result : Result[String, String] = decode_single_argument(req)
+    match message_result {
+      Ok(message) => js_error = Some(message)
+      Err(message) =>
+        js_error = Some("Failed to decode plugin failure payload: " + message)
+    }
+    webview.response(request_id, 0, "null")
+    webview.terminate()
+  })
+  webview.bind("reportPluginResponse", fn(id, req) {
+    let request_id = @ffi.from_cstr(id)
+    let response_result : Result[@webview.CommandResponse, String] = decode_single_argument(
+      req,
+    )
+    match response_result {
+      Ok(response) => {
+        seen_response = Some(response)
+        finish()
+      }
+      Err(message) => {
+        js_error = Some("Failed to decode plugin response payload: " + message)
+        webview.terminate()
+      }
+    }
+    webview.response(request_id, 0, "null")
+  })
+  webview.bind("reportPluginEvent", fn(id, req) {
+    let request_id = @ffi.from_cstr(id)
+    let event_result : Result[PluginNoticeEvent, String] = decode_single_argument(
+      req,
+    )
+    match event_result {
+      Ok(event) => {
+        seen_event = Some(event)
+        finish()
+      }
+      Err(message) => {
+        js_error = Some("Failed to decode plugin event payload: " + message)
+        webview.terminate()
+      }
+    }
+    webview.response(request_id, 0, "null")
+  })
+  webview.set_html(
+    (
+      #| <html>
+      #|   <body>
+      #|     <script>
+      #|       const reportFailure = (message) =>
+      #|         window.reportPluginFailure(message).catch(() => {});
+      #|       window.addEventListener("error", (event) => {
+      #|         void reportFailure("window error: " + String(event.message));
+      #|       });
+      #|       window.addEventListener("unhandledrejection", (event) => {
+      #|         void reportFailure("unhandled rejection: " + String(event.reason));
+      #|       });
+      #|       window.addEventListener("load", () => {
+      #|         const plugins = window.MoonBitPlugins;
+      #|         if (!plugins || !plugins["@@has"]("math", "multiply")) {
+      #|           void reportFailure("plugin api missing");
+      #|           return;
+      #|         }
+      #|         plugins.math["@@onEvent"]("computed", (event) => {
+      #|           void window.reportPluginEvent(event).catch(() => {});
+      #|         });
+      #|         plugins.math
+      #|           .multiply({ left: 6, right: 7 })
+      #|           .then((response) =>
+      #|             window.reportPluginResponse(response).catch(() => {}))
+      #|           .catch((error) => {
+      #|             void reportFailure("plugin transport error: " + String(error));
+      #|           });
+      #|       });
+      #|     </script>
+      #|   </body>
+      #| </html>,
+    ),
+  )
+  plugins.run()
+  assert_eq(seen_response, Some(expected_response))
+  assert_eq(seen_event, Some(expected_event))
+  assert_eq(js_error, None)
+}
+
+///|
 test "panic CommandBridge::new rejects duplicate binding names" {
   let webview = @webview.Webview::new()
   let _first = @webview.CommandBridge::new(webview)
   let _second = @webview.CommandBridge::new(webview)
+}
+
+///|
+test "panic PluginHost::install rejects duplicate plugin names" {
+  let webview = @webview.Webview::new()
+  let plugins = @webview.PluginHost::new(webview)
+  let plugin = @webview.Plugin::new("math", fn(_plugin) {  })
+  plugins.install(plugin)
+  plugins.install(plugin)
+}
+
+///|
+test "panic PluginHost::install rejects reserved plugin names" {
+  let webview = @webview.Webview::new()
+  let plugins = @webview.PluginHost::new(webview)
+  plugins.install(@webview.Plugin::new("@@internal", fn(_plugin) {  }))
+}
+
+///|
+test "Plugin lifecycle hooks run on install and destroy" {
+  let mut installed_plugin : String? = None
+  let mut destroyed_plugin : String? = None
+  let webview = @webview.Webview::new()
+  let plugins = @webview.PluginHost::new(webview)
+  plugins.install(
+    @webview.Plugin::new(
+      "math",
+      fn(_plugin) {  },
+      on_install=fn(plugin) { installed_plugin = Some(plugin.name()) },
+      on_destroy=fn(plugin) { destroyed_plugin = Some(plugin.name()) },
+    ),
+  )
+  assert_eq(installed_plugin, Some("math"))
+  assert_eq(destroyed_plugin, None)
+  plugins.destroy()
+  assert_eq(destroyed_plugin, Some("math"))
+}
+
+///|
+test "PluginHost::install allows helper-like plugin names outside the @@ namespace" {
+  let webview = @webview.Webview::new()
+  let plugins = @webview.PluginHost::new(webview)
+  plugins.install(@webview.Plugin::new("call", fn(_plugin) {  }))
+}
+
+///|
+test "panic PluginContext::command rejects reserved API names" {
+  let webview = @webview.Webview::new()
+  let plugins = @webview.PluginHost::new(webview)
+  plugins.install(
+    @webview.Plugin::new("math", fn(plugin) {
+      plugin.command("@@on", fn(payload : Json) { payload })
+    }),
+  )
+}
+
+///|
+test "panic PluginContext::command rejects duplicate APIs" {
+  let webview = @webview.Webview::new()
+  let plugins = @webview.PluginHost::new(webview)
+  plugins.install(
+    @webview.Plugin::new("math", fn(plugin) {
+      plugin.command("identity", fn(payload : Json) { payload })
+      plugin.command("identity", fn(payload : Json) { payload })
+    }),
+  )
 }
 
 ///|


### PR DESCRIPTION
## Summary
- add a first-class plugin system so MoonBit modules can be installed into a main webview program and exposed to JavaScript as namespaced APIs
- build the plugin host on top of the existing command bridge instead of adding a separate transport layer
- add lifecycle hooks and plugin-scoped event emission so plugins can both serve JS calls and push notifications back into the page

## What changed
- add `Plugin`, `PluginHost`, `PluginContext`, and `PluginEvent` in `src/plugin.mbt`
- expose installed plugin APIs under `window.MoonBitPlugins.<plugin>.<api>(payload)` and a root helper `window.MoonBitPlugins["@@call"](plugin, api, payload)`
- expose plugin event listeners through `window.MoonBitPlugins.<plugin>["@@on"](...)` and `window.MoonBitPlugins.<plugin>["@@onEvent"](...)`
- reserve the `@@` namespace for framework/internal plugin names and API names
- run plugin destroy hooks in `PluginHost::run()` before the native webview is destroyed
- export the new surface in `src/pkg.generated.mbti`
- document the plugin system in `README.md`
- add a dedicated `examples/17_plugin` example showing module-defined plugin installation, JS API calls, and plugin event subscription
- expand the native test suite to cover plugin API exposure, lifecycle hooks, event emission, duplicate registration rejection, and reserved-name enforcement

## API notes
- a plugin is defined as a MoonBit module that returns a `@webview.Plugin`
- the main program installs plugins through `PluginHost::install(...)`
- plugin commands are registered through `PluginContext::command(...)` or `PluginContext::command_result(...)`
- plugin events can be emitted from plugin code through `PluginContext::emit(...)` or from the host through `PluginHost::emit(...)`
- helper keys on the JS host are all reserved under the `@@` prefix

## Verification
- `moon check --target native`
- `moon check --target native` in `test/`
- `moon check --target native` in `examples/17_plugin/`
- `DYLD_LIBRARY_PATH=../lib moon test --target native` in `test/` using the real macOS webview backend outside the sandbox
