### PR TITLE
feat: add native fs plugin module with dedicated demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,10 +195,13 @@ fn main {
 
 ## Plugin System
 
-For module-level JS APIs, build on top of `CommandBridge` with `PluginHost`.
+For module-level JS APIs, install `Plugin` modules on a `Webview`. The default
+plugin runtime is built on top of `CommandBridge` and exposed as
+`window.MoonBitPlugins`.
 
 - A MoonBit module exports a `Plugin`.
-- The main program installs that plugin on a `PluginHost`.
+- The main program usually installs that plugin with
+  `webview.install_plugin(...)`.
 - Plugins can define native install/destroy hooks.
 - JavaScript calls the installed API through
   `window.MoonBitPlugins.<plugin>.<api>(payload)` or
@@ -248,8 +251,7 @@ pub fn math_plugin() -> @webview.Plugin {
 
 fn main {
   let webview = @webview.Webview::new(debug=1)
-  let plugins = @webview.PluginHost::new(webview)
-  plugins.install(math_plugin())
+  webview.install_plugin(math_plugin())
   webview.set_html(
     #| <script>
     #|   window.MoonBitPlugins.math["@@onEvent"]("computed", (event) => {
@@ -267,17 +269,24 @@ fn main {
     #|     .catch(console.error);
     #| </script>,
   )
-  plugins.run()
+  webview.run()
 }
 ```
 
 Notes:
-- `PluginHost` uses `CommandBridge` internally; access it with
-  `plugins.command_bridge()` if you need lower-level command registration too.
-- Use `plugins.emit(plugin, name, payload)` when the main program, rather than a
-  plugin context, needs to push a plugin-scoped event into JavaScript.
-- Use `plugins.run()` when you need plugin `on_destroy` hooks to run as part of
-  normal application shutdown.
+- `webview.install_plugin(...)` uses a default `PluginHost` under
+  `window.MoonBitPlugins`.
+- Use `webview.emit_plugin(plugin, name, payload)` when the main program,
+  rather than a plugin context, needs to push a plugin-scoped event into
+  JavaScript.
+- `webview.plugin_host()` returns that default host if you need direct access to
+  `PluginHost` or the underlying `CommandBridge`.
+- You can still construct `PluginHost::new(...)` directly when you need custom
+  JS namespace or bridge names.
+- Reusable plugins can live in separate MoonBit modules such as
+  [plugins/fs/README.md](plugins/fs/README.md).
+- Plugin cleanup is attached to the `Webview` lifecycle, so `on_destroy` hooks
+  run during normal `webview.run()` / `webview.destroy()`.
 - Install a plugin before loading content if you want the JS API to exist on the
   first page load.
 - Plugin names and API names starting with `@@` are reserved for
@@ -309,7 +318,8 @@ This repository includes several examples in the `examples/` directory:
 - **14_beforeunload** - Handling window close events
 - **15_close** - Window close management
 - **16_command** - Structured JS <-> MoonBit command bridge
-- **17_plugin** - Plugin modules exposed as JavaScript APIs
+- **17_plugin** - Generic plugin modules exposed as JavaScript APIs
+- **18_plugin_fs** - Filesystem plugin module example
 
 Run any example:
 

--- a/README.md
+++ b/README.md
@@ -285,6 +285,9 @@ Notes:
   JS namespace or bridge names.
 - Reusable plugins can live in separate MoonBit modules such as
   [plugins/fs/README.md](plugins/fs/README.md).
+- Plugin modules can add utility APIs beyond handle-based commands. For
+  example, the fs plugin exposes `fs.resolvePath({ path })` so JavaScript can
+  ask the native backend for the platform-specific absolute path.
 - Plugin cleanup is attached to the `Webview` lifecycle, so `on_destroy` hooks
   run during normal `webview.run()` / `webview.destroy()`.
 - Install a plugin before loading content if you want the JS API to exist on the
@@ -319,7 +322,7 @@ This repository includes several examples in the `examples/` directory:
 - **15_close** - Window close management
 - **16_command** - Structured JS <-> MoonBit command bridge
 - **17_plugin** - Generic plugin modules exposed as JavaScript APIs
-- **18_plugin_fs** - Filesystem plugin module example
+- **18_plugin_fs** - Filesystem plugin workbench with absolute-path resolution
 
 Run any example:
 

--- a/examples/17_plugin/main.mbt
+++ b/examples/17_plugin/main.mbt
@@ -41,8 +41,8 @@ let html =
   #|   </head>
   #|   <body>
   #|     <main>
-  #|       <h1>Plugin Host</h1>
-  #|       <p>A MoonBit plugin module installs a namespaced JS API and event stream on <code>window.MoonBitPlugins</code>, and each call returns a structured <code>CommandResponse</code>.</p>
+  #|       <h1>Plugin API</h1>
+  #|       <p>A MoonBit plugin module installs a namespaced JS API and event stream on <code>window.MoonBitPlugins</code>.</p>
   #|       <button id="run">Call math.sum</button>
   #|       <pre id="output">Click the button.</pre>
   #|     </main>
@@ -58,14 +58,9 @@ let html =
   #|         window.MoonBitPlugins.math
   #|           .sum({ left: 20, right: 22 })
   #|           .then((response) => {
-  #|             if (response.status === "ok") {
-  #|               output.textContent =
-  #|                 "Plugin payload:\n" + JSON.stringify(response.payload, null, 2) +
-  #|                 "\n\nLast event:\n" + JSON.stringify(lastEvent, null, 2);
-  #|               return;
-  #|             }
   #|             output.textContent =
-  #|               "Plugin error:\n" + JSON.stringify(response, null, 2);
+  #|               "Plugin response:\n" + JSON.stringify(response, null, 2) +
+  #|               "\n\nLast event:\n" + JSON.stringify(lastEvent, null, 2);
   #|           })
   #|           .catch((error) => {
   #|             output.textContent = "Transport error:\n" + String(error);
@@ -78,10 +73,9 @@ let html =
 ///|
 fn main {
   let webview = @webview.Webview::new(debug=1)
-  let plugins = @webview.PluginHost::new(webview)
-  plugins.install(plugin())
-  webview.set_title("MoonBit Plugin Host")
+  webview.install_plugin(plugin())
+  webview.set_title("MoonBit Plugin API")
   webview.set_size(900, 640, @webview.SizeHint::None)
   webview.set_html(html)
-  plugins.run()
+  webview.run()
 }

--- a/examples/18_plugin_fs/main.mbt
+++ b/examples/18_plugin_fs/main.mbt
@@ -1,0 +1,151 @@
+///|
+let html =
+  #| <html>
+  #|   <head>
+  #|     <style>
+  #|       body {
+  #|         margin: 0;
+  #|         min-height: 100vh;
+  #|         display: grid;
+  #|         place-items: center;
+  #|         background:
+  #|           radial-gradient(circle at top, #f7f1d9 0%, transparent 42%),
+  #|           linear-gradient(160deg, #dce9f4 0%, #f6efe4 100%);
+  #|         color: #14212b;
+  #|         font-family: "Avenir Next", "Gill Sans", sans-serif;
+  #|       }
+  #|       main {
+  #|         width: min(34rem, calc(100vw - 3rem));
+  #|         padding: 2rem;
+  #|         border-radius: 22px;
+  #|         background: rgba(255, 255, 255, 0.84);
+  #|         box-shadow: 0 24px 70px rgba(20, 33, 43, 0.14);
+  #|       }
+  #|       button {
+  #|         border: 0;
+  #|         border-radius: 999px;
+  #|         padding: 0.85rem 1.2rem;
+  #|         background: #14212b;
+  #|         color: white;
+  #|         font: inherit;
+  #|         cursor: pointer;
+  #|       }
+  #|       pre {
+  #|         margin-top: 1rem;
+  #|         padding: 1rem;
+  #|         border-radius: 14px;
+  #|         background: #eef3f7;
+  #|         white-space: pre-wrap;
+  #|       }
+  #|     </style>
+  #|   </head>
+  #|   <body>
+  #|     <main>
+  #|       <h1>Filesystem Plugin</h1>
+  #|       <p>The <code>fs</code> plugin exposes handle-based file operations through <code>window.MoonBitPlugins.fs</code>.</p>
+  #|       <label>
+  #|         File path
+  #|         <input id="path" value="/tmp/moonbit-webview-plugin-demo.txt" />
+  #|       </label>
+  #|       <label>
+  #|         Content
+  #|         <textarea id="content">Hello from the fs plugin.</textarea>
+  #|       </label>
+  #|       <div class="actions">
+  #|         <button id="roundTrip">Open / write / fstat / read / close</button>
+  #|         <button id="listDir">List parent directory</button>
+  #|         <button id="remove">Remove file</button>
+  #|       </div>
+  #|       <pre id="output">Run an fs operation.</pre>
+  #|     </main>
+  #|     <script>
+  #|       const output = document.getElementById("output");
+  #|       const pathInput = document.getElementById("path");
+  #|       const contentInput = document.getElementById("content");
+  #|       let lastEvent = null;
+  #|       const fs = window.MoonBitPlugins.fs;
+  #|       const expectOk = (response) => {
+  #|         if (response.status === "ok") {
+  #|           return response.payload;
+  #|         }
+  #|         throw new Error(response.error || "Plugin command failed");
+  #|       };
+  #|       const parentDir = (path) => {
+  #|         const separator = path.lastIndexOf("/");
+  #|         return separator <= 0 ? "/" : path.slice(0, separator);
+  #|       };
+  #|       fs["@@onEvent"]("activity", (event) => {
+  #|         lastEvent = event;
+  #|       });
+  #|       document.getElementById("roundTrip").addEventListener("click", async () => {
+  #|         const path = pathInput.value.trim();
+  #|         const content = contentInput.value;
+  #|         try {
+  #|           const opened = expectOk(await fs.open({ path, mode: "w+b" }));
+  #|           const handle = opened.handle;
+  #|           const written = expectOk(await fs.write({ handle, content }));
+  #|           expectOk(await fs.flush({ handle }));
+  #|           const rewound = expectOk(await fs.seek({
+  #|             handle,
+  #|             offset: 0,
+  #|             whence: "set",
+  #|           }));
+  #|           const stat = expectOk(await fs.fstat({ handle }));
+  #|           const read = expectOk(await fs.read({ handle, size: 4096 }));
+  #|           const closed = expectOk(await fs.close({ handle }));
+  #|           const exists = expectOk(await fs.exists({ path }));
+  #|           output.textContent =
+  #|             "Round trip result:\n" +
+  #|             JSON.stringify(
+  #|               {
+  #|                 opened,
+  #|                 written,
+  #|                 rewound,
+  #|                 stat,
+  #|                 read,
+  #|                 closed,
+  #|                 exists,
+  #|                 lastEvent,
+  #|               },
+  #|               null,
+  #|               2,
+  #|             );
+  #|         } catch (error) {
+  #|           output.textContent = "FS error:\n" + String(error);
+  #|         }
+  #|       });
+  #|       document.getElementById("listDir").addEventListener("click", async () => {
+  #|         const path = pathInput.value.trim();
+  #|         try {
+  #|           const entries = expectOk(await fs.readDir({ path: parentDir(path) }));
+  #|           output.textContent =
+  #|             "Directory entries:\n" +
+  #|             JSON.stringify({ entries, lastEvent }, null, 2);
+  #|         } catch (error) {
+  #|           output.textContent = "FS error:\n" + String(error);
+  #|         }
+  #|       });
+  #|       document.getElementById("remove").addEventListener("click", async () => {
+  #|         const path = pathInput.value.trim();
+  #|         try {
+  #|           const removed = expectOk(await fs.removeFile({ path }));
+  #|           output.textContent =
+  #|             "Remove result:\n" +
+  #|             JSON.stringify({ removed, lastEvent }, null, 2);
+  #|         } catch (error) {
+  #|           output.textContent = "FS error:\n" + String(error);
+  #|         }
+  #|       });
+  #|     </script>
+  #|   </body>
+  #| </html>
+
+///|
+fn main {
+  let webview = @webview.Webview::new(debug=1)
+  webview.install_plugin(@fs.plugin())
+  webview.set_title("MoonBit Filesystem Plugin")
+  webview.set_size(960, 720, @webview.SizeHint::None)
+  webview.set_html(html)
+  webview.run()
+}

--- a/examples/18_plugin_fs/main.mbt
+++ b/examples/18_plugin_fs/main.mbt
@@ -224,12 +224,12 @@ let html =
   #|             <div class="form">
   #|               <label>
   #|                 File path
-  #|                 <input id="path" value="/tmp/moonbit-webview-plugin-demo.txt" />
+  #|                 <input id="path" value="moonbit-webview-plugin-demo.txt" />
   #|               </label>
   #|               <label>
   #|                 Content
   #|                 <textarea id="content">Hello from the fs plugin.
-  #| 
+  #|
   #| This demo writes text through MoonBit, reads it back, and shows plugin activity emitted from the native side.</textarea>
   #|               </label>
   #|               <div class="actions">
@@ -308,7 +308,7 @@ let html =
   #|       var lastReadAt = "-";
   #|       var lastWriteAt = "-";
   #|       var activityLog = [];
-  #| 
+  #|
   #|       function expectOk(response) {
   #|         if (response.status === "ok") {
   #|           return response.payload;
@@ -317,8 +317,20 @@ let html =
   #|       }
   #| 
   #|       function parentDir(path) {
-  #|         var separator = path.lastIndexOf("/");
-  #|         return separator <= 0 ? "/" : path.slice(0, separator);
+  #|         var normalized = String(path || "");
+  #|         var slashIndex = normalized.lastIndexOf("/");
+  #|         var backslashIndex = normalized.lastIndexOf("\\");
+  #|         var separator = Math.max(slashIndex, backslashIndex);
+  #|         if (separator < 0) {
+  #|           return ".";
+  #|         }
+  #|         if (separator === 2 && normalized.charAt(1) === ":") {
+  #|           return normalized.slice(0, 3);
+  #|         }
+  #|         if (separator === 0) {
+  #|           return normalized.slice(0, 1);
+  #|         }
+  #|         return normalized.slice(0, separator);
   #|       }
   #| 
   #|       function nowLabel() {
@@ -413,6 +425,21 @@ let html =
   #|         renderActivityLog();
   #|       }
   #| 
+  #|       function resolvePath(path) {
+  #|         return fs.resolvePath({ path: path }).then(function(response) {
+  #|           return expectOk(response).path;
+  #|         });
+  #|       }
+  #|       function resolveInputPath() {
+  #|         var path = pathInput.value.trim();
+  #|         if (!path) {
+  #|           return Promise.resolve("");
+  #|         }
+  #|         return resolvePath(path).then(function(resolvedPath) {
+  #|           pathInput.value = resolvedPath;
+  #|           return resolvedPath;
+  #|         });
+  #|       }
   #|       function withOpenFile(path, mode, callback) {
   #|         return fs.open({ path: path, mode: mode }).then(function(response) {
   #|           var opened = expectOk(response);
@@ -475,15 +502,17 @@ let html =
   #|         return fs.exists({ path: path }).then(function(response) {
   #|           var exists = expectOk(response);
   #|           if (!exists.exists) {
-  #|             return {
-  #|               path: path,
-  #|               size: 0,
-  #|               position: 0,
-  #|               eof: false,
-  #|               exists: false,
-  #|               is_file: false,
-  #|               is_dir: false,
-  #|             };
+  #|             return resolvePath(path).then(function(resolvedPath) {
+  #|               return {
+  #|                 path: resolvedPath,
+  #|                 size: 0,
+  #|                 position: 0,
+  #|                 eof: false,
+  #|                 exists: false,
+  #|                 is_file: false,
+  #|                 is_dir: false,
+  #|               };
+  #|             });
   #|           }
   #|           return withOpenFile(path, "rb", function(handle) {
   #|             return fs.fstat({ handle: handle }).then(function(response) {
@@ -514,11 +543,14 @@ let html =
   #|           return;
   #|         }
   #|         setBusy(true);
-  #|         saveFile(path, contentInput.value).then(
+  #|         resolveInputPath().then(function(path) {
+  #|           return saveFile(path, contentInput.value);
+  #|         }).then(
   #|           function(result) {
   #|             lastWriteAt = nowLabel();
   #|             renderStat(result.stat);
-  #|             setNotice("Saved " + result.written.bytes_written + " bytes to " + path + ".");
+  #|             pathInput.value = result.stat.path || pathInput.value;
+  #|             setNotice("Saved " + result.written.bytes_written + " bytes to " + (result.stat.path || pathInput.value) + ".");
   #|             setBusy(false);
   #|           },
   #|           function(error) {
@@ -535,12 +567,15 @@ let html =
   #|           return;
   #|         }
   #|         setBusy(true);
-  #|         loadFile(path).then(
+  #|         resolveInputPath().then(function(path) {
+  #|           return loadFile(path);
+  #|         }).then(
   #|           function(result) {
   #|             contentInput.value = result.read.content;
   #|             lastReadAt = nowLabel();
   #|             renderStat(result.stat);
-  #|             setNotice("Loaded " + result.read.bytes_read + " bytes from " + path + ".");
+  #|             pathInput.value = result.stat.path || pathInput.value;
+  #|             setNotice("Loaded " + result.read.bytes_read + " bytes from " + (result.stat.path || pathInput.value) + ".");
   #|             setBusy(false);
   #|           },
   #|           function(error) {
@@ -557,10 +592,18 @@ let html =
   #|           return;
   #|         }
   #|         setBusy(true);
-  #|         inspectFile(path).then(
+  #|         resolveInputPath().then(function(path) {
+  #|           return inspectFile(path);
+  #|         }).then(
   #|           function(stat) {
   #|             renderStat(stat);
-  #|             setNotice(stat.exists ? "Inspected " + path + "." : path + " does not exist yet.", stat.exists ? "ok" : "error");
+  #|             pathInput.value = stat.path || pathInput.value;
+  #|             setNotice(
+  #|               stat.exists
+  #|                 ? "Inspected " + (stat.path || pathInput.value) + "."
+  #|                 : (stat.path || pathInput.value) + " does not exist yet.",
+  #|               stat.exists ? "ok" : "error",
+  #|             );
   #|             setBusy(false);
   #|           },
   #|           function(error) {
@@ -571,13 +614,19 @@ let html =
   #|       });
   #| 
   #|       document.getElementById("listDir").addEventListener("click", function() {
-  #|         var path = pathInput.value.trim();
   #|         setBusy(true);
-  #|         fs.readDir({ path: parentDir(path) }).then(
+  #|         resolveInputPath().then(function(path) {
+  #|           var directoryPath = parentDir(path);
+  #|           return fs.readDir({ path: directoryPath }).then(function(response) {
+  #|             return {
+  #|               directoryPath: directoryPath,
+  #|               entries: expectOk(response).entries,
+  #|             };
+  #|           });
+  #|         }).then(
   #|           function(response) {
-  #|             var entries = expectOk(response);
-  #|             renderDirEntries(entries.entries);
-  #|             setNotice("Listed " + entries.entries.length + " entries in " + parentDir(path) + ".");
+  #|             renderDirEntries(response.entries);
+  #|             setNotice("Listed " + response.entries.length + " entries in " + response.directoryPath + ".");
   #|             setBusy(false);
   #|           },
   #|           function(error) {
@@ -594,11 +643,17 @@ let html =
   #|           return;
   #|         }
   #|         setBusy(true);
-  #|         fs.removeFile({ path: path }).then(
-  #|           function(response) {
-  #|             var removed = expectOk(response);
-  #|             renderStat({
+  #|         resolveInputPath().then(function(path) {
+  #|           return fs.removeFile({ path: path }).then(function(response) {
+  #|             return {
   #|               path: path,
+  #|               removed: expectOk(response),
+  #|             };
+  #|           });
+  #|         }).then(
+  #|           function(result) {
+  #|             renderStat({
+  #|               path: result.path,
   #|               size: 0,
   #|               position: 0,
   #|               eof: false,
@@ -606,9 +661,10 @@ let html =
   #|               is_file: false,
   #|               is_dir: false,
   #|             });
+  #|             pathInput.value = result.path;
   #|             setNotice(
-  #|               removed.removed ? "Deleted " + path + "." : path + " was already absent.",
-  #|               removed.removed ? "ok" : "error",
+  #|               result.removed.removed ? "Deleted " + result.path + "." : result.path + " was already absent.",
+  #|               result.removed.removed ? "ok" : "error",
   #|             );
   #|             setBusy(false);
   #|           },
@@ -621,6 +677,14 @@ let html =
   #| 
   #|       renderStat(null);
   #|       renderActivityLog();
+  #|       resolveInputPath().then(
+  #|         function() {
+  #|           renderStat(null);
+  #|         },
+  #|         function(error) {
+  #|           setNotice("Could not resolve the default path: " + String(error), "error");
+  #|         },
+  #|       );
   #|     </script>
   #|   </body>
   #| </html>

--- a/examples/18_plugin_fs/main.mbt
+++ b/examples/18_plugin_fs/main.mbt
@@ -6,136 +6,621 @@ let html =
   #|       body {
   #|         margin: 0;
   #|         min-height: 100vh;
-  #|         display: grid;
-  #|         place-items: center;
   #|         background:
-  #|           radial-gradient(circle at top, #f7f1d9 0%, transparent 42%),
-  #|           linear-gradient(160deg, #dce9f4 0%, #f6efe4 100%);
-  #|         color: #14212b;
+  #|           radial-gradient(circle at top left, #f4e6bb 0%, transparent 35%),
+  #|           linear-gradient(160deg, #dce8f4 0%, #f6efe4 100%);
+  #|         color: #15222c;
   #|         font-family: "Avenir Next", "Gill Sans", sans-serif;
   #|       }
-  #|       main {
-  #|         width: min(34rem, calc(100vw - 3rem));
-  #|         padding: 2rem;
-  #|         border-radius: 22px;
-  #|         background: rgba(255, 255, 255, 0.84);
-  #|         box-shadow: 0 24px 70px rgba(20, 33, 43, 0.14);
+  #|       .shell {
+  #|         width: min(72rem, calc(100vw - 2rem));
+  #|         margin: 1rem auto;
+  #|         padding: 1.25rem;
+  #|         border-radius: 26px;
+  #|         background: rgba(255, 255, 255, 0.9);
+  #|         border: 1px solid rgba(255, 255, 255, 0.7);
+  #|         box-shadow: 0 24px 80px rgba(21, 34, 44, 0.16);
+  #|       }
+  #|       h1,
+  #|       h2,
+  #|       p {
+  #|         margin: 0;
+  #|       }
+  #|       .hero {
+  #|         display: grid;
+  #|         gap: 0.75rem;
+  #|         margin-bottom: 1rem;
+  #|       }
+  #|       .hero p {
+  #|         color: #61737c;
+  #|         max-width: 48rem;
+  #|       }
+  #|       .hero code {
+  #|         padding: 0.15rem 0.4rem;
+  #|         border-radius: 999px;
+  #|         background: #dceef0;
+  #|       }
+  #|       .layout {
+  #|         display: grid;
+  #|         grid-template-columns: minmax(0, 1.45fr) minmax(18rem, 0.95fr);
+  #|         gap: 1rem;
+  #|       }
+  #|       .column {
+  #|         display: grid;
+  #|         gap: 1rem;
+  #|       }
+  #|       .panel {
+  #|         padding: 1rem;
+  #|         border-radius: 20px;
+  #|         background: #eef3f6;
+  #|         border: 1px solid rgba(21, 34, 44, 0.12);
+  #|       }
+  #|       .panel-head {
+  #|         display: flex;
+  #|         align-items: center;
+  #|         justify-content: space-between;
+  #|         gap: 0.75rem;
+  #|         margin-bottom: 0.9rem;
+  #|       }
+  #|       .muted {
+  #|         color: #61737c;
+  #|         font-size: 0.95rem;
+  #|       }
+  #|       .form {
+  #|         display: grid;
+  #|         gap: 0.85rem;
+  #|       }
+  #|       label {
+  #|         display: grid;
+  #|         gap: 0.35rem;
+  #|         font-size: 0.95rem;
+  #|         font-weight: 600;
+  #|       }
+  #|       input,
+  #|       textarea {
+  #|         width: 100%;
+  #|         box-sizing: border-box;
+  #|         border: 1px solid rgba(21, 34, 44, 0.12);
+  #|         border-radius: 14px;
+  #|         background: rgba(255, 255, 255, 0.92);
+  #|         color: #15222c;
+  #|         font: inherit;
+  #|         padding: 0.8rem 0.95rem;
+  #|       }
+  #|       textarea {
+  #|         min-height: 16rem;
+  #|         resize: vertical;
+  #|         line-height: 1.45;
+  #|       }
+  #|       .actions {
+  #|         display: grid;
+  #|         grid-template-columns: repeat(2, minmax(0, 1fr));
+  #|         gap: 0.75rem;
   #|       }
   #|       button {
   #|         border: 0;
   #|         border-radius: 999px;
-  #|         padding: 0.85rem 1.2rem;
-  #|         background: #14212b;
+  #|         padding: 0.82rem 1rem;
+  #|         background: #15222c;
   #|         color: white;
   #|         font: inherit;
+  #|         font-weight: 600;
   #|         cursor: pointer;
   #|       }
-  #|       pre {
-  #|         margin-top: 1rem;
-  #|         padding: 1rem;
+  #|       button.secondary {
+  #|         background: #0e6c75;
+  #|       }
+  #|       button.ghost {
+  #|         background: white;
+  #|         color: #15222c;
+  #|         border: 1px solid rgba(21, 34, 44, 0.12);
+  #|       }
+  #|       button.danger {
+  #|         background: #9a3d32;
+  #|       }
+  #|       button:disabled {
+  #|         opacity: 0.6;
+  #|         cursor: progress;
+  #|       }
+  #|       .notice {
+  #|         border-radius: 16px;
+  #|         padding: 0.8rem 0.95rem;
+  #|         background: white;
+  #|         border: 1px solid rgba(21, 34, 44, 0.12);
+  #|         line-height: 1.45;
+  #|       }
+  #|       .notice.ok {
+  #|         background: #dceff1;
+  #|       }
+  #|       .notice.error {
+  #|         background: #f7dfdb;
+  #|       }
+  #|       .chips {
+  #|         display: flex;
+  #|         flex-wrap: wrap;
+  #|         gap: 0.55rem;
+  #|         margin-top: 0.75rem;
+  #|       }
+  #|       .chip {
+  #|         border-radius: 999px;
+  #|         padding: 0.45rem 0.7rem;
+  #|         background: white;
+  #|         border: 1px solid rgba(21, 34, 44, 0.12);
+  #|         font-size: 0.92rem;
+  #|       }
+  #|       .chip strong {
+  #|         margin-right: 0.35rem;
+  #|         color: #61737c;
+  #|         text-transform: uppercase;
+  #|         font-size: 0.78rem;
+  #|       }
+  #|       .meta {
+  #|         display: grid;
+  #|         grid-template-columns: repeat(2, minmax(0, 1fr));
+  #|         gap: 0.6rem;
+  #|         margin-top: 0.75rem;
+  #|       }
+  #|       .meta-card {
   #|         border-radius: 14px;
-  #|         background: #eef3f7;
-  #|         white-space: pre-wrap;
+  #|         padding: 0.75rem 0.85rem;
+  #|         background: white;
+  #|         border: 1px solid rgba(21, 34, 44, 0.12);
+  #|       }
+  #|       .meta-card strong {
+  #|         display: block;
+  #|         margin-bottom: 0.2rem;
+  #|         color: #61737c;
+  #|         font-size: 0.78rem;
+  #|         text-transform: uppercase;
+  #|       }
+  #|       .list {
+  #|         margin: 0;
+  #|         padding: 0;
+  #|         list-style: none;
+  #|         display: grid;
+  #|         gap: 0.45rem;
+  #|         max-height: 15rem;
+  #|         overflow: auto;
+  #|       }
+  #|       .list li {
+  #|         border-radius: 14px;
+  #|         background: white;
+  #|         border: 1px solid rgba(21, 34, 44, 0.12);
+  #|         padding: 0.7rem 0.8rem;
+  #|         font-family: "SF Mono", "Menlo", monospace;
+  #|         font-size: 0.88rem;
+  #|       }
+  #|       .empty {
+  #|         color: #61737c;
+  #|         font-style: italic;
+  #|       }
+  #|       @media (max-width: 860px) {
+  #|         .layout {
+  #|           grid-template-columns: 1fr;
+  #|         }
+  #|         .actions,
+  #|         .meta {
+  #|           grid-template-columns: 1fr;
+  #|         }
   #|       }
   #|     </style>
   #|   </head>
   #|   <body>
-  #|     <main>
-  #|       <h1>Filesystem Plugin</h1>
-  #|       <p>The <code>fs</code> plugin exposes handle-based file operations through <code>window.MoonBitPlugins.fs</code>.</p>
-  #|       <label>
-  #|         File path
-  #|         <input id="path" value="/tmp/moonbit-webview-plugin-demo.txt" />
-  #|       </label>
-  #|       <label>
-  #|         Content
-  #|         <textarea id="content">Hello from the fs plugin.</textarea>
-  #|       </label>
-  #|       <div class="actions">
-  #|         <button id="roundTrip">Open / write / fstat / read / close</button>
-  #|         <button id="listDir">List parent directory</button>
-  #|         <button id="remove">Remove file</button>
+  #|     <div class="shell">
+  #|       <div class="hero">
+  #|         <h1>Filesystem Plugin Demo</h1>
+  #|         <p>Use <code>window.MoonBitPlugins.fs</code> like a small file workbench: edit text, save it, load it back, inspect file metadata, browse the parent directory, and watch native plugin activity.</p>
   #|       </div>
-  #|       <pre id="output">Run an fs operation.</pre>
-  #|     </main>
+  #|       <div class="layout">
+  #|         <div class="column">
+  #|           <div class="panel">
+  #|             <div class="panel-head">
+  #|               <div>
+  #|                 <h2>Editor</h2>
+  #|                 <p class="muted">Work with a UTF-8 text file on disk.</p>
+  #|               </div>
+  #|               <button id="seed" class="ghost">Insert Sample</button>
+  #|             </div>
+  #|             <div class="form">
+  #|               <label>
+  #|                 File path
+  #|                 <input id="path" value="/tmp/moonbit-webview-plugin-demo.txt" />
+  #|               </label>
+  #|               <label>
+  #|                 Content
+  #|                 <textarea id="content">Hello from the fs plugin.
+  #| 
+  #| This demo writes text through MoonBit, reads it back, and shows plugin activity emitted from the native side.</textarea>
+  #|               </label>
+  #|               <div class="actions">
+  #|                 <button id="save">Save File</button>
+  #|                 <button id="load" class="secondary">Load File</button>
+  #|                 <button id="inspect" class="ghost">Inspect File</button>
+  #|                 <button id="delete" class="danger">Delete File</button>
+  #|               </div>
+  #|             </div>
+  #|           </div>
+  #|           <div class="panel">
+  #|             <div class="panel-head">
+  #|               <div>
+  #|                 <h2>Directory</h2>
+  #|                 <p class="muted">List entries next to the current file path.</p>
+  #|               </div>
+  #|               <button id="listDir" class="ghost">Refresh List</button>
+  #|             </div>
+  #|             <ul id="dirList" class="list">
+  #|               <li class="empty">No directory listing yet.</li>
+  #|             </ul>
+  #|           </div>
+  #|         </div>
+  #|         <div class="column">
+  #|           <div class="panel">
+  #|             <div class="panel-head">
+  #|               <div>
+  #|                 <h2>File State</h2>
+  #|                 <p class="muted">Latest metadata and command status.</p>
+  #|               </div>
+  #|             </div>
+  #|             <div id="notice" class="notice">Ready.</div>
+  #|             <div class="chips">
+  #|               <div class="chip"><strong>Exists</strong><span id="existsChip">Unknown</span></div>
+  #|               <div class="chip"><strong>Size</strong><span id="sizeChip">-</span></div>
+  #|               <div class="chip"><strong>Position</strong><span id="positionChip">-</span></div>
+  #|               <div class="chip"><strong>EOF</strong><span id="eofChip">-</span></div>
+  #|             </div>
+  #|             <div class="meta">
+  #|               <div class="meta-card"><strong>Path</strong><span id="metaPath">-</span></div>
+  #|               <div class="meta-card"><strong>Type</strong><span id="metaType">-</span></div>
+  #|               <div class="meta-card"><strong>Last Read</strong><span id="metaRead">-</span></div>
+  #|               <div class="meta-card"><strong>Last Write</strong><span id="metaWrite">-</span></div>
+  #|             </div>
+  #|           </div>
+  #|           <div class="panel">
+  #|             <div class="panel-head">
+  #|               <div>
+  #|                 <h2>Plugin Activity</h2>
+  #|                 <p class="muted">Recent events emitted by the native fs plugin.</p>
+  #|               </div>
+  #|             </div>
+  #|             <ul id="eventLog" class="list">
+  #|               <li class="empty">No plugin events yet.</li>
+  #|             </ul>
+  #|           </div>
+  #|         </div>
+  #|       </div>
+  #|     </div>
   #|     <script>
-  #|       const output = document.getElementById("output");
-  #|       const pathInput = document.getElementById("path");
-  #|       const contentInput = document.getElementById("content");
-  #|       let lastEvent = null;
-  #|       const fs = window.MoonBitPlugins.fs;
-  #|       const expectOk = (response) => {
+  #|       var pathInput = document.getElementById("path");
+  #|       var contentInput = document.getElementById("content");
+  #|       var dirList = document.getElementById("dirList");
+  #|       var eventLog = document.getElementById("eventLog");
+  #|       var notice = document.getElementById("notice");
+  #|       var existsChip = document.getElementById("existsChip");
+  #|       var sizeChip = document.getElementById("sizeChip");
+  #|       var positionChip = document.getElementById("positionChip");
+  #|       var eofChip = document.getElementById("eofChip");
+  #|       var metaPath = document.getElementById("metaPath");
+  #|       var metaType = document.getElementById("metaType");
+  #|       var metaRead = document.getElementById("metaRead");
+  #|       var metaWrite = document.getElementById("metaWrite");
+  #|       var buttons = Array.prototype.slice.call(document.querySelectorAll("button"));
+  #|       var fs = window.MoonBitPlugins.fs;
+  #|       var lastReadAt = "-";
+  #|       var lastWriteAt = "-";
+  #|       var activityLog = [];
+  #| 
+  #|       function expectOk(response) {
   #|         if (response.status === "ok") {
   #|           return response.payload;
   #|         }
   #|         throw new Error(response.error || "Plugin command failed");
-  #|       };
-  #|       const parentDir = (path) => {
-  #|         const separator = path.lastIndexOf("/");
+  #|       }
+  #| 
+  #|       function parentDir(path) {
+  #|         var separator = path.lastIndexOf("/");
   #|         return separator <= 0 ? "/" : path.slice(0, separator);
-  #|       };
-  #|       fs["@@onEvent"]("activity", (event) => {
-  #|         lastEvent = event;
+  #|       }
+  #| 
+  #|       function nowLabel() {
+  #|         return new Date().toLocaleTimeString([], {
+  #|           hour: "2-digit",
+  #|           minute: "2-digit",
+  #|           second: "2-digit",
+  #|         });
+  #|       }
+  #| 
+  #|       function setBusy(busy) {
+  #|         buttons.forEach(function(button) {
+  #|           button.disabled = busy;
+  #|         });
+  #|       }
+  #| 
+  #|       function setNotice(message, kind) {
+  #|         notice.textContent = message;
+  #|         notice.className = "notice " + (kind || "ok");
+  #|       }
+  #| 
+  #|       function renderStat(stat) {
+  #|         existsChip.textContent = stat ? (stat.exists ? "Yes" : "No") : "Unknown";
+  #|         sizeChip.textContent = stat ? stat.size + " bytes" : "-";
+  #|         positionChip.textContent = stat ? String(stat.position) : "-";
+  #|         eofChip.textContent = stat ? (stat.eof ? "Yes" : "No") : "-";
+  #|         metaPath.textContent = stat && stat.path ? stat.path : (pathInput.value.trim() || "-");
+  #|         metaType.textContent = !stat
+  #|           ? "-"
+  #|           : stat.is_dir
+  #|             ? "Directory"
+  #|             : stat.is_file
+  #|               ? "File"
+  #|               : "Missing";
+  #|         metaRead.textContent = lastReadAt;
+  #|         metaWrite.textContent = lastWriteAt;
+  #|       }
+  #| 
+  #|       function renderDirEntries(entries) {
+  #|         dirList.innerHTML = "";
+  #|         if (!entries.length) {
+  #|           var emptyItem = document.createElement("li");
+  #|           emptyItem.className = "empty";
+  #|           emptyItem.textContent = "The directory is empty.";
+  #|           dirList.appendChild(emptyItem);
+  #|           return;
+  #|         }
+  #|         entries.forEach(function(entry) {
+  #|           var item = document.createElement("li");
+  #|           item.textContent = entry;
+  #|           dirList.appendChild(item);
+  #|         });
+  #|       }
+  #| 
+  #|       function renderActivityLog() {
+  #|         eventLog.innerHTML = "";
+  #|         if (!activityLog.length) {
+  #|           var emptyItem = document.createElement("li");
+  #|           emptyItem.className = "empty";
+  #|           emptyItem.textContent = "No plugin events yet.";
+  #|           eventLog.appendChild(emptyItem);
+  #|           return;
+  #|         }
+  #|         activityLog.forEach(function(entry) {
+  #|           var item = document.createElement("li");
+  #|           item.textContent = entry.operation + entry.detail;
+  #|           var line = document.createElement("div");
+  #|           line.className = "muted";
+  #|           line.textContent = entry.time;
+  #|           item.appendChild(line);
+  #|           eventLog.appendChild(item);
+  #|         });
+  #|       }
+  #| 
+  #|       function rememberActivity(event) {
+  #|         var bits = [];
+  #|         if (event.payload.path) {
+  #|           bits.push(event.payload.path);
+  #|         }
+  #|         if (event.payload.handle != null) {
+  #|           bits.push("handle " + event.payload.handle);
+  #|         }
+  #|         if (event.payload.bytes != null) {
+  #|           bits.push(event.payload.bytes + " bytes");
+  #|         }
+  #|         activityLog.unshift({
+  #|           operation: event.payload.operation,
+  #|           detail: bits.length ? " - " + bits.join(" - ") : "",
+  #|           time: nowLabel(),
+  #|         });
+  #|         activityLog = activityLog.slice(0, 8);
+  #|         renderActivityLog();
+  #|       }
+  #| 
+  #|       function withOpenFile(path, mode, callback) {
+  #|         return fs.open({ path: path, mode: mode }).then(function(response) {
+  #|           var opened = expectOk(response);
+  #|           var handle = opened.handle;
+  #|           return callback(handle).then(
+  #|             function(result) {
+  #|               return fs.close({ handle: handle }).then(function() {
+  #|                 return result;
+  #|               });
+  #|             },
+  #|             function(error) {
+  #|               return fs.close({ handle: handle }).then(function() {
+  #|                 throw error;
+  #|               });
+  #|             },
+  #|           );
+  #|         });
+  #|       }
+  #| 
+  #|       function saveFile(path, content) {
+  #|         return withOpenFile(path, "w+b", function(handle) {
+  #|           return fs.write({ handle: handle, content: content })
+  #|             .then(function(response) {
+  #|               var written = expectOk(response);
+  #|               return fs.flush({ handle: handle }).then(function() {
+  #|                 return written;
+  #|               });
+  #|             })
+  #|             .then(function(written) {
+  #|               return fs.seek({ handle: handle, offset: 0, whence: "set" }).then(function() {
+  #|                 return written;
+  #|               });
+  #|             })
+  #|             .then(function(written) {
+  #|               return fs.fstat({ handle: handle }).then(function(response) {
+  #|                 return {
+  #|                   written: written,
+  #|                   stat: expectOk(response),
+  #|                 };
+  #|               });
+  #|             });
+  #|         });
+  #|       }
+  #| 
+  #|       function loadFile(path) {
+  #|         return withOpenFile(path, "rb", function(handle) {
+  #|           return fs.fstat({ handle: handle }).then(function(response) {
+  #|             var stat = expectOk(response);
+  #|             return fs.read({ handle: handle, size: Math.max(stat.size, 1) + 1 }).then(function(response) {
+  #|               return {
+  #|                 stat: stat,
+  #|                 read: expectOk(response),
+  #|               };
+  #|             });
+  #|           });
+  #|         });
+  #|       }
+  #| 
+  #|       function inspectFile(path) {
+  #|         return fs.exists({ path: path }).then(function(response) {
+  #|           var exists = expectOk(response);
+  #|           if (!exists.exists) {
+  #|             return {
+  #|               path: path,
+  #|               size: 0,
+  #|               position: 0,
+  #|               eof: false,
+  #|               exists: false,
+  #|               is_file: false,
+  #|               is_dir: false,
+  #|             };
+  #|           }
+  #|           return withOpenFile(path, "rb", function(handle) {
+  #|             return fs.fstat({ handle: handle }).then(function(response) {
+  #|               return expectOk(response);
+  #|             });
+  #|           });
+  #|         });
+  #|       }
+  #| 
+  #|       fs["@@onEvent"]("activity", function(event) {
+  #|         rememberActivity(event);
   #|       });
-  #|       document.getElementById("roundTrip").addEventListener("click", async () => {
-  #|         const path = pathInput.value.trim();
-  #|         const content = contentInput.value;
-  #|         try {
-  #|           const opened = expectOk(await fs.open({ path, mode: "w+b" }));
-  #|           const handle = opened.handle;
-  #|           const written = expectOk(await fs.write({ handle, content }));
-  #|           expectOk(await fs.flush({ handle }));
-  #|           const rewound = expectOk(await fs.seek({
-  #|             handle,
-  #|             offset: 0,
-  #|             whence: "set",
-  #|           }));
-  #|           const stat = expectOk(await fs.fstat({ handle }));
-  #|           const read = expectOk(await fs.read({ handle, size: 4096 }));
-  #|           const closed = expectOk(await fs.close({ handle }));
-  #|           const exists = expectOk(await fs.exists({ path }));
-  #|           output.textContent =
-  #|             "Round trip result:\n" +
-  #|             JSON.stringify(
-  #|               {
-  #|                 opened,
-  #|                 written,
-  #|                 rewound,
-  #|                 stat,
-  #|                 read,
-  #|                 closed,
-  #|                 exists,
-  #|                 lastEvent,
-  #|               },
-  #|               null,
-  #|               2,
+  #| 
+  #|       document.getElementById("seed").addEventListener("click", function() {
+  #|         contentInput.value =
+  #|           "MoonBit fs plugin demo\n\n" +
+  #|           "- Save writes the editor content to disk\n" +
+  #|           "- Load reads the file back into the editor\n" +
+  #|           "- Inspect shows fstat metadata\n" +
+  #|           "- Refresh List shows sibling files\n";
+  #|         setNotice("Sample content inserted into the editor.");
+  #|       });
+  #| 
+  #|       document.getElementById("save").addEventListener("click", function() {
+  #|         var path = pathInput.value.trim();
+  #|         if (!path) {
+  #|           setNotice("Enter a file path before saving.", "error");
+  #|           return;
+  #|         }
+  #|         setBusy(true);
+  #|         saveFile(path, contentInput.value).then(
+  #|           function(result) {
+  #|             lastWriteAt = nowLabel();
+  #|             renderStat(result.stat);
+  #|             setNotice("Saved " + result.written.bytes_written + " bytes to " + path + ".");
+  #|             setBusy(false);
+  #|           },
+  #|           function(error) {
+  #|             setNotice("Save failed: " + String(error), "error");
+  #|             setBusy(false);
+  #|           },
+  #|         );
+  #|       });
+  #| 
+  #|       document.getElementById("load").addEventListener("click", function() {
+  #|         var path = pathInput.value.trim();
+  #|         if (!path) {
+  #|           setNotice("Enter a file path before loading.", "error");
+  #|           return;
+  #|         }
+  #|         setBusy(true);
+  #|         loadFile(path).then(
+  #|           function(result) {
+  #|             contentInput.value = result.read.content;
+  #|             lastReadAt = nowLabel();
+  #|             renderStat(result.stat);
+  #|             setNotice("Loaded " + result.read.bytes_read + " bytes from " + path + ".");
+  #|             setBusy(false);
+  #|           },
+  #|           function(error) {
+  #|             setNotice("Load failed: " + String(error), "error");
+  #|             setBusy(false);
+  #|           },
+  #|         );
+  #|       });
+  #| 
+  #|       document.getElementById("inspect").addEventListener("click", function() {
+  #|         var path = pathInput.value.trim();
+  #|         if (!path) {
+  #|           setNotice("Enter a file path before inspecting.", "error");
+  #|           return;
+  #|         }
+  #|         setBusy(true);
+  #|         inspectFile(path).then(
+  #|           function(stat) {
+  #|             renderStat(stat);
+  #|             setNotice(stat.exists ? "Inspected " + path + "." : path + " does not exist yet.", stat.exists ? "ok" : "error");
+  #|             setBusy(false);
+  #|           },
+  #|           function(error) {
+  #|             setNotice("Inspect failed: " + String(error), "error");
+  #|             setBusy(false);
+  #|           },
+  #|         );
+  #|       });
+  #| 
+  #|       document.getElementById("listDir").addEventListener("click", function() {
+  #|         var path = pathInput.value.trim();
+  #|         setBusy(true);
+  #|         fs.readDir({ path: parentDir(path) }).then(
+  #|           function(response) {
+  #|             var entries = expectOk(response);
+  #|             renderDirEntries(entries.entries);
+  #|             setNotice("Listed " + entries.entries.length + " entries in " + parentDir(path) + ".");
+  #|             setBusy(false);
+  #|           },
+  #|           function(error) {
+  #|             setNotice("Directory listing failed: " + String(error), "error");
+  #|             setBusy(false);
+  #|           },
+  #|         );
+  #|       });
+  #| 
+  #|       document.getElementById("delete").addEventListener("click", function() {
+  #|         var path = pathInput.value.trim();
+  #|         if (!path) {
+  #|           setNotice("Enter a file path before deleting.", "error");
+  #|           return;
+  #|         }
+  #|         setBusy(true);
+  #|         fs.removeFile({ path: path }).then(
+  #|           function(response) {
+  #|             var removed = expectOk(response);
+  #|             renderStat({
+  #|               path: path,
+  #|               size: 0,
+  #|               position: 0,
+  #|               eof: false,
+  #|               exists: false,
+  #|               is_file: false,
+  #|               is_dir: false,
+  #|             });
+  #|             setNotice(
+  #|               removed.removed ? "Deleted " + path + "." : path + " was already absent.",
+  #|               removed.removed ? "ok" : "error",
   #|             );
-  #|         } catch (error) {
-  #|           output.textContent = "FS error:\n" + String(error);
-  #|         }
+  #|             setBusy(false);
+  #|           },
+  #|           function(error) {
+  #|             setNotice("Delete failed: " + String(error), "error");
+  #|             setBusy(false);
+  #|           },
+  #|         );
   #|       });
-  #|       document.getElementById("listDir").addEventListener("click", async () => {
-  #|         const path = pathInput.value.trim();
-  #|         try {
-  #|           const entries = expectOk(await fs.readDir({ path: parentDir(path) }));
-  #|           output.textContent =
-  #|             "Directory entries:\n" +
-  #|             JSON.stringify({ entries, lastEvent }, null, 2);
-  #|         } catch (error) {
-  #|           output.textContent = "FS error:\n" + String(error);
-  #|         }
-  #|       });
-  #|       document.getElementById("remove").addEventListener("click", async () => {
-  #|         const path = pathInput.value.trim();
-  #|         try {
-  #|           const removed = expectOk(await fs.removeFile({ path }));
-  #|           output.textContent =
-  #|             "Remove result:\n" +
-  #|             JSON.stringify({ removed, lastEvent }, null, 2);
-  #|         } catch (error) {
-  #|           output.textContent = "FS error:\n" + String(error);
-  #|         }
-  #|       });
+  #| 
+  #|       renderStat(null);
+  #|       renderActivityLog();
   #|     </script>
   #|   </body>
   #| </html>

--- a/examples/18_plugin_fs/moon.pkg
+++ b/examples/18_plugin_fs/moon.pkg
@@ -1,5 +1,5 @@
 import {
-  "moonbitlang/core/json",
+  "plugins/fs",
   "justjavac/webview",
 }
 
@@ -12,5 +12,5 @@ options(
     },
   },
   "supported-targets": [ "native" ],
-  targets: { "main.mbt": [ "native" ], "math_plugin.mbt": [ "native" ] },
+  targets: { "main.mbt": [ "native" ] },
 )

--- a/examples/Readme.md
+++ b/examples/Readme.md
@@ -16,4 +16,5 @@
 | 12_embed        | ✓      |                                         |
 | 13_todo         | ✓      |                                         |
 | 16_command      | ✓      | Structured JS <-> MoonBit bridge       |
-| 17_plugin       | ✓      | Plugin modules exposed as JS APIs      |
+| 17_plugin       | ✓      | Generic plugin modules exposed as JS APIs |
+| 18_plugin_fs    | ✓      | Filesystem plugin module example       |

--- a/examples/Readme.md
+++ b/examples/Readme.md
@@ -17,4 +17,4 @@
 | 13_todo         | ✓      |                                         |
 | 16_command      | ✓      | Structured JS <-> MoonBit bridge       |
 | 17_plugin       | ✓      | Generic plugin modules exposed as JS APIs |
-| 18_plugin_fs    | ✓      | Filesystem plugin module example       |
+| 18_plugin_fs    | ✓      | Filesystem plugin workbench with absolute paths |

--- a/examples/moon.mod.json
+++ b/examples/moon.mod.json
@@ -3,6 +3,9 @@
   "version": "0.1.0",
   "deps": {
     "justjavac/ffi": "0.1.12",
+    "plugins": {
+      "path": "../plugins"
+    },
     "justjavac/webview": {
       "path": ".."
     }

--- a/plugins/README.md
+++ b/plugins/README.md
@@ -1,0 +1,56 @@
+# Plugins
+
+This workspace contains reusable MoonBit plugins built on top of
+`justjavac/webview`'s plugin system.
+
+Most applications should install them directly on a `Webview` with
+`webview.install_plugin(...)`. The lower-level `PluginHost` API is still
+available when you need a custom JS namespace or bridge configuration.
+
+## Layout
+
+- `fs/`: handle-based filesystem plugin for native webview applications
+
+## Usage
+
+Add the workspace as a local dependency:
+
+```json
+{
+  "deps": {
+    "plugins": {
+      "path": "../plugins"
+    }
+  }
+}
+```
+
+Then import the plugin package you want in your `moon.pkg`:
+
+```moonbit
+import {
+  "plugins/fs",
+  "justjavac/webview",
+}
+```
+
+And install it from your main program:
+
+```moonbit
+fn main {
+  let webview = @webview.Webview::new(debug=1)
+  webview.install_plugin(@fs.plugin())
+  webview.set_html("<script>console.log(window.MoonBitPlugins.fs);</script>")
+  webview.run()
+}
+```
+
+## Notes
+
+- These plugins currently target `native`.
+- JS calls return `CommandResponse` values, so check `status` before reading
+  `payload`.
+- Plugin events are available through `window.MoonBitPlugins.<plugin>["@@on"]`
+  and `["@@onEvent"]`.
+- Use `webview.plugin_host()` only when you need direct access to the default
+  `PluginHost`.

--- a/plugins/README.md
+++ b/plugins/README.md
@@ -50,6 +50,9 @@ fn main {
 - These plugins currently target `native`.
 - JS calls return `CommandResponse` values, so check `status` before reading
   `payload`.
+- Plugins may expose native utility commands in addition to handle-based APIs.
+  For example, `fs.resolvePath({ path })` resolves a portable input into a
+  platform-specific absolute path.
 - Plugin events are available through `window.MoonBitPlugins.<plugin>["@@on"]`
   and `["@@onEvent"]`.
 - Use `webview.plugin_host()` only when you need direct access to the default

--- a/plugins/fs/README.md
+++ b/plugins/fs/README.md
@@ -29,7 +29,7 @@ All fs commands resolve to `CommandResponse`:
 
 ```js
 const response = await window.MoonBitPlugins.fs.open({
-  path: "/tmp/demo.txt",
+  path: "demo.txt",
   mode: "w+b",
 });
 
@@ -58,6 +58,8 @@ if (response.status === "ok") {
   Closes the open handle.
 - `fs.exists({ path })`
   Returns `{ exists }`.
+- `fs.resolvePath({ path })`
+  Returns `{ path }` with the native absolute path for the given input.
 - `fs.readDir({ path })`
   Returns `{ entries }`.
 - `fs.removeFile({ path })`
@@ -87,6 +89,10 @@ Event payload shape:
 ## Notes
 
 - This plugin currently targets the native backend.
+- Use relative paths like `demo.txt` for portable examples across macOS, Linux,
+  and Windows.
+- `open` stores the resolved absolute path for each handle, so `fstat({ handle
+  })` reports an absolute `path`.
 - `read` and `write` use UTF-8 text payloads.
 - `fstat` is handle-based; if you also want path-based metadata, add a separate
   `stat` command.

--- a/plugins/fs/README.md
+++ b/plugins/fs/README.md
@@ -97,6 +97,9 @@ Event payload shape:
 ## Notes
 
 - This plugin currently targets the native backend.
+- This plugin exposes direct host filesystem access. Only use it with trusted,
+  local HTML/JavaScript content; do not install it in webviews that navigate to
+  untrusted or remote pages.
 - Use relative paths like `demo.txt` for portable examples across macOS, Linux,
   and Windows.
 - Resolve relative paths with `fs.resolvePath({ path })` when the UI should

--- a/plugins/fs/README.md
+++ b/plugins/fs/README.md
@@ -40,6 +40,14 @@ if (response.status === "ok") {
 }
 ```
 
+If you want the native absolute path before opening a file, resolve it first:
+
+```js
+const resolved = await window.MoonBitPlugins.fs.resolvePath({
+  path: "demo.txt",
+});
+```
+
 ### Commands
 
 - `fs.open({ path, mode })`
@@ -91,6 +99,8 @@ Event payload shape:
 - This plugin currently targets the native backend.
 - Use relative paths like `demo.txt` for portable examples across macOS, Linux,
   and Windows.
+- Resolve relative paths with `fs.resolvePath({ path })` when the UI should
+  display the actual absolute location chosen by the native runtime.
 - `open` stores the resolved absolute path for each handle, so `fstat({ handle
   })` reports an absolute `path`.
 - `read` and `write` use UTF-8 text payloads.

--- a/plugins/fs/README.md
+++ b/plugins/fs/README.md
@@ -1,0 +1,92 @@
+# FS Plugin
+
+Native filesystem plugin for `justjavac/webview` applications.
+
+It exposes a handle-based API under `window.MoonBitPlugins.fs` and is intended
+to be installed through `Webview::install_plugin(...)`.
+
+This is a reusable MoonBit module, so applications can add it as a dependency
+and install it without wiring command bindings manually.
+
+## Install
+
+```moonbit
+import {
+  "plugins/fs",
+  "justjavac/webview",
+}
+
+fn main {
+  let webview = @webview.Webview::new(debug=1)
+  webview.install_plugin(@fs.plugin())
+  webview.run()
+}
+```
+
+## JavaScript API
+
+All fs commands resolve to `CommandResponse`:
+
+```js
+const response = await window.MoonBitPlugins.fs.open({
+  path: "/tmp/demo.txt",
+  mode: "w+b",
+});
+
+if (response.status === "ok") {
+  console.log(response.payload);
+} else {
+  console.error(response.error);
+}
+```
+
+### Commands
+
+- `fs.open({ path, mode })`
+  Returns `{ handle }`.
+- `fs.read({ handle, size })`
+  Returns `{ content, bytes_read, eof }`.
+- `fs.write({ handle, content })`
+  Returns `{ bytes_written }`.
+- `fs.seek({ handle, offset, whence })`
+  `whence` is `"set"`, `"current"`, or `"end"`.
+- `fs.fstat({ handle })`
+  Returns `{ path, size, position, eof, exists, is_file, is_dir }`.
+- `fs.flush({ handle })`
+  Flushes buffered writes.
+- `fs.close({ handle })`
+  Closes the open handle.
+- `fs.exists({ path })`
+  Returns `{ exists }`.
+- `fs.readDir({ path })`
+  Returns `{ entries }`.
+- `fs.removeFile({ path })`
+  Returns `{ removed }`.
+
+## Events
+
+The plugin emits an `activity` event after successful operations:
+
+```js
+window.MoonBitPlugins.fs["@@onEvent"]("activity", (event) => {
+  console.log(event);
+});
+```
+
+Event payload shape:
+
+```js
+{
+  operation: "open" | "read" | "write" | "seek" | "fstat" | "flush" | "close" | "readDir" | "removeFile",
+  path: string | null,
+  handle: number | null,
+  bytes: number | null
+}
+```
+
+## Notes
+
+- This plugin currently targets the native backend.
+- `read` and `write` use UTF-8 text payloads.
+- `fstat` is handle-based; if you also want path-based metadata, add a separate
+  `stat` command.

--- a/plugins/fs/fs_native.c
+++ b/plugins/fs/fs_native.c
@@ -202,6 +202,9 @@ MOONBIT_FFI_EXPORT moonbit_bytes_t *plugins_fs_read_dir(moonbit_bytes_t path) {
   FindClose(dir);
   dir = FindFirstFile(search_path, &find_data);
   free(search_path);
+  if (dir == INVALID_HANDLE_VALUE) {
+    return NULL;
+  }
 
   result = (moonbit_bytes_t *)moonbit_make_ref_array(count, NULL);
   if (result == NULL) {

--- a/plugins/fs/fs_native.c
+++ b/plugins/fs/fs_native.c
@@ -3,7 +3,9 @@ extern "C" {
 #endif
 
 #include <errno.h>
+#include <limits.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 #include <sys/stat.h>
 
@@ -11,9 +13,27 @@ extern "C" {
 #include <windows.h>
 #else
 #include <dirent.h>
+#include <unistd.h>
 #endif
 
 #include "moonbit.h"
+
+static moonbit_bytes_t plugins_fs_copy_string(const char *value) {
+  size_t len = strlen(value);
+  moonbit_bytes_t bytes = moonbit_make_bytes(len, 0);
+  memcpy(bytes, value, len);
+  return bytes;
+}
+
+static int plugins_fs_is_absolute_path(const char *path) {
+#ifdef _WIN32
+  return (strlen(path) >= 3 && path[1] == ':' &&
+          (path[2] == '\\' || path[2] == '/')) ||
+         (strlen(path) >= 2 && path[0] == '\\' && path[1] == '\\');
+#else
+  return path[0] == '/';
+#endif
+}
 
 MOONBIT_FFI_EXPORT FILE *plugins_fs_fopen(moonbit_bytes_t path,
                                           moonbit_bytes_t mode) {
@@ -93,6 +113,63 @@ MOONBIT_FFI_EXPORT int plugins_fs_is_dir(moonbit_bytes_t path) {
 
 MOONBIT_FFI_EXPORT int plugins_fs_remove_file(moonbit_bytes_t path) {
   return remove((const char *)path);
+}
+
+MOONBIT_FFI_EXPORT moonbit_bytes_t plugins_fs_absolute_path(
+    moonbit_bytes_t path) {
+  const char *input = (const char *)path;
+
+#ifdef _WIN32
+  DWORD length = GetFullPathNameA(input, 0, NULL, NULL);
+  if (length == 0) {
+    return plugins_fs_copy_string(input);
+  }
+
+  char *buffer = malloc(length);
+  if (buffer == NULL) {
+    return plugins_fs_copy_string(input);
+  }
+
+  DWORD written = GetFullPathNameA(input, length, buffer, NULL);
+  if (written == 0 || written >= length) {
+    free(buffer);
+    return plugins_fs_copy_string(input);
+  }
+
+  moonbit_bytes_t result = plugins_fs_copy_string(buffer);
+  free(buffer);
+  return result;
+#else
+  char resolved[PATH_MAX];
+  if (realpath(input, resolved) != NULL) {
+    moonbit_bytes_t result = plugins_fs_copy_string(resolved);
+    return result;
+  }
+
+  if (plugins_fs_is_absolute_path(input)) {
+    return plugins_fs_copy_string(input);
+  }
+
+  char cwd[PATH_MAX];
+  if (getcwd(cwd, sizeof(cwd)) == NULL) {
+    return plugins_fs_copy_string(input);
+  }
+
+  size_t cwd_len = strlen(cwd);
+  size_t input_len = strlen(input);
+  char *joined = malloc(cwd_len + input_len + 2);
+  if (joined == NULL) {
+    return plugins_fs_copy_string(input);
+  }
+
+  memcpy(joined, cwd, cwd_len);
+  joined[cwd_len] = '/';
+  memcpy(joined + cwd_len + 1, input, input_len + 1);
+
+  moonbit_bytes_t result = plugins_fs_copy_string(joined);
+  free(joined);
+  return result;
+#endif
 }
 
 MOONBIT_FFI_EXPORT moonbit_bytes_t *plugins_fs_read_dir(moonbit_bytes_t path) {

--- a/plugins/fs/fs_native.c
+++ b/plugins/fs/fs_native.c
@@ -1,0 +1,189 @@
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <errno.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/stat.h>
+
+#ifdef _WIN32
+#include <windows.h>
+#else
+#include <dirent.h>
+#endif
+
+#include "moonbit.h"
+
+MOONBIT_FFI_EXPORT FILE *plugins_fs_fopen(moonbit_bytes_t path,
+                                          moonbit_bytes_t mode) {
+  return fopen((const char *)path, (const char *)mode);
+}
+
+MOONBIT_FFI_EXPORT size_t plugins_fs_fread(moonbit_bytes_t ptr, int size,
+                                           int nitems, FILE *stream) {
+  return fread(ptr, size, nitems, stream);
+}
+
+MOONBIT_FFI_EXPORT size_t plugins_fs_fwrite(moonbit_bytes_t ptr, int size,
+                                            int nitems, FILE *stream) {
+  return fwrite(ptr, size, nitems, stream);
+}
+
+MOONBIT_FFI_EXPORT int plugins_fs_fseek(FILE *stream, long offset, int whence) {
+  return fseek(stream, offset, whence);
+}
+
+MOONBIT_FFI_EXPORT long plugins_fs_ftell(FILE *stream) { return ftell(stream); }
+
+MOONBIT_FFI_EXPORT int plugins_fs_fflush(FILE *stream) { return fflush(stream); }
+
+MOONBIT_FFI_EXPORT int plugins_fs_fclose(FILE *stream) { return fclose(stream); }
+
+MOONBIT_FFI_EXPORT int plugins_fs_feof(FILE *stream) { return feof(stream); }
+
+MOONBIT_FFI_EXPORT int plugins_fs_ferror(FILE *stream) { return ferror(stream); }
+
+MOONBIT_FFI_EXPORT void plugins_fs_clearerr(FILE *stream) { clearerr(stream); }
+
+MOONBIT_FFI_EXPORT moonbit_bytes_t plugins_fs_get_error_message(void) {
+  const char *err_str = strerror(errno);
+  size_t len = strlen(err_str);
+  moonbit_bytes_t bytes = moonbit_make_bytes(len, 0);
+  memcpy(bytes, err_str, len);
+  return bytes;
+}
+
+MOONBIT_FFI_EXPORT int plugins_fs_path_exists(moonbit_bytes_t path) {
+  struct stat buffer;
+  return stat((const char *)path, &buffer) == 0;
+}
+
+MOONBIT_FFI_EXPORT int plugins_fs_is_file(moonbit_bytes_t path) {
+#ifdef _WIN32
+  DWORD attrs = GetFileAttributes((const char *)path);
+  if (attrs == INVALID_FILE_ATTRIBUTES) {
+    return 0;
+  }
+  return !(attrs & FILE_ATTRIBUTE_DIRECTORY);
+#else
+  struct stat buffer;
+  if (stat((const char *)path, &buffer) != 0) {
+    return 0;
+  }
+  return S_ISREG(buffer.st_mode);
+#endif
+}
+
+MOONBIT_FFI_EXPORT int plugins_fs_is_dir(moonbit_bytes_t path) {
+#ifdef _WIN32
+  DWORD attrs = GetFileAttributes((const char *)path);
+  if (attrs == INVALID_FILE_ATTRIBUTES) {
+    return 0;
+  }
+  return (attrs & FILE_ATTRIBUTE_DIRECTORY) != 0;
+#else
+  struct stat buffer;
+  if (stat((const char *)path, &buffer) != 0) {
+    return 0;
+  }
+  return S_ISDIR(buffer.st_mode);
+#endif
+}
+
+MOONBIT_FFI_EXPORT int plugins_fs_remove_file(moonbit_bytes_t path) {
+  return remove((const char *)path);
+}
+
+MOONBIT_FFI_EXPORT moonbit_bytes_t *plugins_fs_read_dir(moonbit_bytes_t path) {
+#ifdef _WIN32
+  WIN32_FIND_DATA find_data;
+  HANDLE dir;
+  moonbit_bytes_t *result = NULL;
+  int count = 0;
+
+  size_t path_len = strlen((const char *)path);
+  char *search_path = malloc(path_len + 3);
+  if (search_path == NULL) {
+    return NULL;
+  }
+
+  sprintf(search_path, "%s\\*", (const char *)path);
+  dir = FindFirstFile(search_path, &find_data);
+  if (dir == INVALID_HANDLE_VALUE) {
+    free(search_path);
+    return NULL;
+  }
+
+  do {
+    if (strcmp(find_data.cFileName, ".") != 0 &&
+        strcmp(find_data.cFileName, "..") != 0) {
+      count++;
+    }
+  } while (FindNextFile(dir, &find_data));
+
+  FindClose(dir);
+  dir = FindFirstFile(search_path, &find_data);
+  free(search_path);
+
+  result = (moonbit_bytes_t *)moonbit_make_ref_array(count, NULL);
+  if (result == NULL) {
+    FindClose(dir);
+    return NULL;
+  }
+
+  int index = 0;
+  do {
+    if (strcmp(find_data.cFileName, ".") != 0 &&
+        strcmp(find_data.cFileName, "..") != 0) {
+      size_t name_len = strlen(find_data.cFileName);
+      moonbit_bytes_t item = moonbit_make_bytes(name_len, 0);
+      memcpy(item, find_data.cFileName, name_len);
+      result[index++] = item;
+    }
+  } while (FindNextFile(dir, &find_data));
+
+  FindClose(dir);
+  return result;
+#else
+  DIR *dir;
+  struct dirent *entry;
+  moonbit_bytes_t *result = NULL;
+  int count = 0;
+
+  dir = opendir((const char *)path);
+  if (dir == NULL) {
+    return NULL;
+  }
+
+  while ((entry = readdir(dir)) != NULL) {
+    if (strcmp(entry->d_name, ".") != 0 && strcmp(entry->d_name, "..") != 0) {
+      count++;
+    }
+  }
+
+  rewinddir(dir);
+  result = (moonbit_bytes_t *)moonbit_make_ref_array(count, NULL);
+  if (result == NULL) {
+    closedir(dir);
+    return NULL;
+  }
+
+  int index = 0;
+  while ((entry = readdir(dir)) != NULL) {
+    if (strcmp(entry->d_name, ".") != 0 && strcmp(entry->d_name, "..") != 0) {
+      size_t name_len = strlen(entry->d_name);
+      moonbit_bytes_t item = moonbit_make_bytes(name_len, 0);
+      memcpy(item, entry->d_name, name_len);
+      result[index++] = item;
+    }
+  }
+
+  closedir(dir);
+  return result;
+#endif
+}
+
+#ifdef __cplusplus
+}
+#endif

--- a/plugins/fs/moon.pkg
+++ b/plugins/fs/moon.pkg
@@ -1,16 +1,18 @@
 import {
+  "moonbitlang/core/encoding/utf8",
   "moonbitlang/core/json",
+  "justjavac/ffi",
   "justjavac/webview",
 }
 
 options(
-  "is-main": true,
   link: {
     "native": {
       "cc-flags": "-fwrapv -fsanitize=address -fsanitize=undefined",
       "cc-link-flags": "-L../lib -lwebview",
     },
   },
+  "native-stub": [ "fs_native.c" ],
   "supported-targets": [ "native" ],
-  targets: { "main.mbt": [ "native" ], "math_plugin.mbt": [ "native" ] },
+  targets: { "plugin.mbt": [ "native" ] },
 )

--- a/plugins/fs/plugin.mbt
+++ b/plugins/fs/plugin.mbt
@@ -419,6 +419,11 @@ fn native_read_dir(path : String) -> Result[Array[String], String] {
 }
 
 ///|
+/// Resolves a user-provided path string into a native absolute path.
+///
+/// This is useful for UIs that accept portable relative paths but still want to
+/// display or reuse the backend's canonical absolute location.
+///|
 fn native_absolute_path(path : String) -> String {
   @utf8.decode_lossy(absolute_path_ffi(path_to_cstr(path))[:])
 }
@@ -449,7 +454,9 @@ fn emit_activity(
 /// Builds the `fs` plugin.
 ///
 /// Install it with `webview.install_plugin(@fs.plugin())` to expose
-/// `window.MoonBitPlugins.fs` in JavaScript.
+/// `window.MoonBitPlugins.fs` in JavaScript. Opened handles remember their
+/// resolved absolute path, and `resolvePath` is also exposed as a standalone
+/// plugin command for JS callers that need it before opening files.
 pub fn plugin() -> @webview.Plugin {
   let handles : Map[Int, NativeFileHandle] = {}
   let paths : Map[Int, String] = {}
@@ -461,6 +468,9 @@ pub fn plugin() -> @webview.Plugin {
         Err(error) => Err(error)
         Ok(file) => {
           let handle = next_handle
+          // Remember the resolved path once so handle-scoped APIs can report a
+          // stable absolute location even when JS opened the file with a
+          // relative path.
           let resolved_path = native_absolute_path(payload.path)
           next_handle += 1
           handles.set(handle, file)

--- a/plugins/fs/plugin.mbt
+++ b/plugins/fs/plugin.mbt
@@ -1,0 +1,664 @@
+///|
+#external
+priv type NativeFileHandle
+
+///|
+#external
+priv type DirectoryEntriesHandle
+
+///|
+struct OpenPayload {
+  path : String
+  mode : String
+} derive(ToJson, FromJson, Show, Eq)
+
+///|
+struct OpenReply {
+  handle : Int
+} derive(ToJson, FromJson, Show, Eq)
+
+///|
+struct ReadPayload {
+  handle : Int
+  size : Int
+} derive(ToJson, FromJson, Show, Eq)
+
+///|
+struct ReadReply {
+  content : String
+  bytes_read : Int
+  eof : Bool
+} derive(ToJson, FromJson, Show, Eq)
+
+///|
+struct WritePayload {
+  handle : Int
+  content : String
+} derive(ToJson, FromJson, Show, Eq)
+
+///|
+struct WriteReply {
+  bytes_written : Int
+} derive(ToJson, FromJson, Show, Eq)
+
+///|
+struct ClosePayload {
+  handle : Int
+} derive(ToJson, FromJson, Show, Eq)
+
+///|
+struct CloseReply {
+  closed : Bool
+} derive(ToJson, FromJson, Show, Eq)
+
+///|
+struct FlushPayload {
+  handle : Int
+} derive(ToJson, FromJson, Show, Eq)
+
+///|
+struct FlushReply {
+  flushed : Bool
+} derive(ToJson, FromJson, Show, Eq)
+
+///|
+struct SeekPayload {
+  handle : Int
+  offset : Int
+  whence : String
+} derive(ToJson, FromJson, Show, Eq)
+
+///|
+struct SeekReply {
+  position : Int
+} derive(ToJson, FromJson, Show, Eq)
+
+///|
+struct FstatPayload {
+  handle : Int
+} derive(ToJson, FromJson, Show, Eq)
+
+///|
+struct FstatReply {
+  path : String?
+  size : Int
+  position : Int
+  eof : Bool
+  exists : Bool
+  is_file : Bool
+  is_dir : Bool
+} derive(ToJson, FromJson, Show, Eq)
+
+///|
+struct ExistsPayload {
+  path : String
+} derive(ToJson, FromJson, Show, Eq)
+
+///|
+struct ExistsReply {
+  exists : Bool
+} derive(ToJson, FromJson, Show, Eq)
+
+///|
+struct RemoveFilePayload {
+  path : String
+} derive(ToJson, FromJson, Show, Eq)
+
+///|
+struct RemoveFileReply {
+  removed : Bool
+} derive(ToJson, FromJson, Show, Eq)
+
+///|
+struct ReadDirPayload {
+  path : String
+} derive(ToJson, FromJson, Show, Eq)
+
+///|
+struct ReadDirReply {
+  entries : Array[String]
+} derive(ToJson, FromJson, Show, Eq)
+
+///|
+struct FsActivity {
+  operation : String
+  path : String?
+  handle : Int?
+  bytes : Int?
+} derive(ToJson, FromJson, Show, Eq)
+
+///|
+#borrow(path, mode)
+extern "C" fn open_file_ffi(path : Bytes, mode : Bytes) -> NativeFileHandle = "plugins_fs_fopen"
+
+///|
+extern "C" fn file_handle_is_null(handle : NativeFileHandle) -> Bool = "moonbit_is_null"
+
+///|
+#borrow(bytes)
+extern "C" fn read_file_ffi(
+  bytes : Bytes,
+  size : Int,
+  item_count : Int,
+  handle : NativeFileHandle,
+) -> Int = "plugins_fs_fread"
+
+///|
+#borrow(bytes)
+extern "C" fn write_file_ffi(
+  bytes : Bytes,
+  size : Int,
+  item_count : Int,
+  handle : NativeFileHandle,
+) -> Int = "plugins_fs_fwrite"
+
+///|
+extern "C" fn seek_file_ffi(
+  handle : NativeFileHandle,
+  offset : Int,
+  whence : Int,
+) -> Int = "plugins_fs_fseek"
+
+///|
+extern "C" fn tell_file_ffi(handle : NativeFileHandle) -> Int = "plugins_fs_ftell"
+
+///|
+extern "C" fn flush_file_ffi(handle : NativeFileHandle) -> Int = "plugins_fs_fflush"
+
+///|
+extern "C" fn close_file_ffi(handle : NativeFileHandle) -> Int = "plugins_fs_fclose"
+
+///|
+extern "C" fn end_of_file_ffi(handle : NativeFileHandle) -> Int = "plugins_fs_feof"
+
+///|
+extern "C" fn file_error_ffi(handle : NativeFileHandle) -> Int = "plugins_fs_ferror"
+
+///|
+extern "C" fn clear_file_error_ffi(handle : NativeFileHandle) -> Unit = "plugins_fs_clearerr"
+
+///|
+extern "C" fn get_error_message_ffi() -> Bytes = "plugins_fs_get_error_message"
+
+///|
+#borrow(path)
+extern "C" fn path_exists_ffi(path : Bytes) -> Int = "plugins_fs_path_exists"
+
+///|
+#borrow(path)
+extern "C" fn path_is_file_ffi(path : Bytes) -> Int = "plugins_fs_is_file"
+
+///|
+#borrow(path)
+extern "C" fn path_is_dir_ffi(path : Bytes) -> Int = "plugins_fs_is_dir"
+
+///|
+#borrow(path)
+extern "C" fn remove_file_ffi(path : Bytes) -> Int = "plugins_fs_remove_file"
+
+///|
+#borrow(path)
+extern "C" fn read_dir_ffi(path : Bytes) -> DirectoryEntriesHandle = "plugins_fs_read_dir"
+
+///|
+extern "C" fn entries_handle_is_null(handle : DirectoryEntriesHandle) -> Bool = "moonbit_is_null"
+
+///|
+fn directory_entries_to_fixed_array(
+  handle : DirectoryEntriesHandle,
+) -> FixedArray[Bytes] = "%identity"
+
+///|
+fn get_error_message() -> String {
+  @utf8.decode_lossy(get_error_message_ffi()[:])
+}
+
+///|
+fn path_to_cstr(path : String) -> Bytes {
+  @ffi.to_cstr(path)
+}
+
+///|
+fn mode_to_cstr(mode : String) -> Bytes {
+  @ffi.to_cstr(mode)
+}
+
+///|
+fn read_string_bytes(content : String) -> Bytes {
+  @utf8.encode(content)
+}
+
+///|
+fn decode_read_bytes(bytes : Bytes, length : Int) -> String {
+  @utf8.decode_lossy(bytes[:length])
+}
+
+///|
+fn whence_to_int(whence : String) -> Result[Int, String] {
+  match whence {
+    "set" => Ok(0)
+    "current" => Ok(1)
+    "end" => Ok(2)
+    _ => Err("Unsupported whence: " + whence)
+  }
+}
+
+///|
+fn open_native_file(
+  path : String,
+  mode : String,
+) -> Result[NativeFileHandle, String] {
+  let handle = open_file_ffi(path_to_cstr(path), mode_to_cstr(mode))
+  if file_handle_is_null(handle) {
+    Err("Failed to open file: " + get_error_message())
+  } else {
+    Ok(handle)
+  }
+}
+
+///|
+fn read_native_file(
+  handle : NativeFileHandle,
+  size : Int,
+) -> Result[ReadReply, String] {
+  guard size >= 0 else { return Err("Read size must be non-negative") }
+  clear_file_error_ffi(handle)
+  let bytes = Bytes::make(size, b'\x00')
+  let bytes_read = read_file_ffi(bytes, 1, size, handle)
+  guard file_error_ffi(handle) == 0 else {
+    clear_file_error_ffi(handle)
+    return Err("Failed to read file: " + get_error_message())
+  }
+  Ok(ReadReply::{
+    content: decode_read_bytes(bytes, bytes_read),
+    bytes_read,
+    eof: end_of_file_ffi(handle) != 0,
+  })
+}
+
+///|
+fn write_native_file(
+  handle : NativeFileHandle,
+  content : String,
+) -> Result[Int, String] {
+  let bytes = read_string_bytes(content)
+  let bytes_written = write_file_ffi(bytes, 1, bytes.length(), handle)
+  guard bytes_written == bytes.length() else {
+    return Err("Failed to write file: " + get_error_message())
+  }
+  Ok(bytes_written)
+}
+
+///|
+fn flush_native_file(handle : NativeFileHandle) -> Result[Unit, String] {
+  guard flush_file_ffi(handle) == 0 else {
+    return Err("Failed to flush file: " + get_error_message())
+  }
+  Ok(())
+}
+
+///|
+fn seek_native_file(
+  handle : NativeFileHandle,
+  offset : Int,
+  whence : String,
+) -> Result[Int, String] {
+  match whence_to_int(whence) {
+    Err(error) => Err(error)
+    Ok(whence) => {
+      guard seek_file_ffi(handle, offset, whence) == 0 else {
+        return Err("Failed to seek file: " + get_error_message())
+      }
+      let position = tell_file_ffi(handle)
+      guard position >= 0 else {
+        return Err("Failed to query file position: " + get_error_message())
+      }
+      Ok(position)
+    }
+  }
+}
+
+///|
+fn close_native_file(handle : NativeFileHandle) -> Result[Unit, String] {
+  guard close_file_ffi(handle) == 0 else {
+    return Err("Failed to close file: " + get_error_message())
+  }
+  Ok(())
+}
+
+///|
+fn stat_path_flags(path : String?) -> (Bool, Bool, Bool) {
+  match path {
+    None => (false, false, false)
+    Some(path) => {
+      let exists = native_path_exists(path)
+      (
+        exists,
+        exists && path_is_file_ffi(path_to_cstr(path)) != 0,
+        exists && path_is_dir_ffi(path_to_cstr(path)) != 0,
+      )
+    }
+  }
+}
+
+///|
+fn stat_native_file(
+  handle : NativeFileHandle,
+  path : String?,
+) -> Result[FstatReply, String] {
+  let position = tell_file_ffi(handle)
+  guard position >= 0 else {
+    return Err("Failed to query file position: " + get_error_message())
+  }
+  guard seek_file_ffi(handle, 0, 2) == 0 else {
+    return Err("Failed to seek file: " + get_error_message())
+  }
+  let size = tell_file_ffi(handle)
+  guard size >= 0 else {
+    return Err("Failed to query file size: " + get_error_message())
+  }
+  guard seek_file_ffi(handle, position, 0) == 0 else {
+    return Err("Failed to restore file position: " + get_error_message())
+  }
+  let (exists, is_file, is_dir) = stat_path_flags(path)
+  Ok(FstatReply::{
+    path,
+    size,
+    position,
+    eof: end_of_file_ffi(handle) != 0,
+    exists,
+    is_file,
+    is_dir,
+  })
+}
+
+///|
+fn native_path_exists(path : String) -> Bool {
+  path_exists_ffi(path_to_cstr(path)) != 0
+}
+
+///|
+fn native_remove_file(path : String) -> Result[Bool, String] {
+  if !native_path_exists(path) {
+    Ok(false)
+  } else if remove_file_ffi(path_to_cstr(path)) == 0 {
+    Ok(true)
+  } else {
+    Err("Failed to remove file: " + get_error_message())
+  }
+}
+
+///|
+fn native_read_dir(path : String) -> Result[Array[String], String] {
+  let entries = read_dir_ffi(path_to_cstr(path))
+  if entries_handle_is_null(entries) {
+    Err("Failed to read directory: " + get_error_message())
+  } else {
+    Ok(
+      Array::from_fixed_array(directory_entries_to_fixed_array(entries)).map(fn(
+        entry,
+      ) {
+        @utf8.decode_lossy(entry[:])
+      }),
+    )
+  }
+}
+
+///|
+fn get_open_handle(
+  handles : Map[Int, NativeFileHandle],
+  handle : Int,
+) -> Result[NativeFileHandle, String] {
+  match handles.get(handle) {
+    Some(handle) => Ok(handle)
+    None => Err("Unknown fs handle: " + handle.to_string())
+  }
+}
+
+///|
+fn emit_activity(
+  plugin : @webview.PluginContext,
+  operation : String,
+  path? : String? = None,
+  handle? : Int? = None,
+  bytes? : Int? = None,
+) -> Unit {
+  plugin.emit("activity", FsActivity::{ operation, path, handle, bytes })
+}
+
+///|
+/// Builds the `fs` plugin.
+///
+/// Install it with `webview.install_plugin(@fs.plugin())` to expose
+/// `window.MoonBitPlugins.fs` in JavaScript.
+pub fn plugin() -> @webview.Plugin {
+  let handles : Map[Int, NativeFileHandle] = {}
+  let paths : Map[Int, String] = {}
+  let mut next_handle = 1
+
+  @webview.Plugin::new("fs", fn(plugin) {
+    plugin.command_result("open", fn(payload : OpenPayload) {
+      match open_native_file(payload.path, payload.mode) {
+        Err(error) => Err(error)
+        Ok(file) => {
+          let handle = next_handle
+          next_handle += 1
+          handles.set(handle, file)
+          paths.set(handle, payload.path)
+          emit_activity(
+            plugin,
+            "open",
+            path=Some(payload.path),
+            handle=Some(handle),
+          )
+          Ok(OpenReply::{ handle, })
+        }
+      }
+    })
+
+    plugin.command_result("read", fn(payload : ReadPayload) {
+      match get_open_handle(handles, payload.handle) {
+        Err(error) => Err(error)
+        Ok(file) =>
+          match read_native_file(file, payload.size) {
+            Err(error) => Err(error)
+            Ok(reply) => {
+              emit_activity(
+                plugin,
+                "read",
+                path=paths.get(payload.handle),
+                handle=Some(payload.handle),
+                bytes=Some(reply.bytes_read),
+              )
+              Ok(reply)
+            }
+          }
+      }
+    })
+
+    plugin.command_result("write", fn(payload : WritePayload) {
+      match get_open_handle(handles, payload.handle) {
+        Err(error) => Err(error)
+        Ok(file) =>
+          match write_native_file(file, payload.content) {
+            Err(error) => Err(error)
+            Ok(bytes_written) => {
+              emit_activity(
+                plugin,
+                "write",
+                path=paths.get(payload.handle),
+                handle=Some(payload.handle),
+                bytes=Some(bytes_written),
+              )
+              Ok(WriteReply::{ bytes_written, })
+            }
+          }
+      }
+    })
+
+    plugin.command_result("seek", fn(payload : SeekPayload) {
+      match get_open_handle(handles, payload.handle) {
+        Err(error) => Err(error)
+        Ok(file) =>
+          match seek_native_file(file, payload.offset, payload.whence) {
+            Err(error) => Err(error)
+            Ok(position) => {
+              emit_activity(
+                plugin,
+                "seek",
+                path=paths.get(payload.handle),
+                handle=Some(payload.handle),
+              )
+              Ok(SeekReply::{ position, })
+            }
+          }
+      }
+    })
+
+    plugin.command_result("fstat", fn(payload : FstatPayload) {
+      match get_open_handle(handles, payload.handle) {
+        Err(error) => Err(error)
+        Ok(file) =>
+          match stat_native_file(file, paths.get(payload.handle)) {
+            Err(error) => Err(error)
+            Ok(reply) => {
+              emit_activity(
+                plugin,
+                "fstat",
+                path=reply.path,
+                handle=Some(payload.handle),
+                bytes=Some(reply.size),
+              )
+              Ok(reply)
+            }
+          }
+      }
+    })
+
+    plugin.command_result("flush", fn(payload : FlushPayload) {
+      match get_open_handle(handles, payload.handle) {
+        Err(error) => Err(error)
+        Ok(file) =>
+          match flush_native_file(file) {
+            Err(error) => Err(error)
+            Ok(_) => {
+              emit_activity(
+                plugin,
+                "flush",
+                path=paths.get(payload.handle),
+                handle=Some(payload.handle),
+              )
+              Ok(FlushReply::{ flushed: true })
+            }
+          }
+      }
+    })
+
+    plugin.command_result("close", fn(payload : ClosePayload) {
+      match get_open_handle(handles, payload.handle) {
+        Err(error) => Err(error)
+        Ok(file) => {
+          let path = paths.get(payload.handle)
+          handles.remove(payload.handle)
+          paths.remove(payload.handle)
+          match close_native_file(file) {
+            Err(error) => Err(error)
+            Ok(_) => {
+              emit_activity(plugin, "close", path~, handle=Some(payload.handle))
+              Ok(CloseReply::{ closed: true })
+            }
+          }
+        }
+      }
+    })
+
+    plugin.command_result("exists", fn(payload : ExistsPayload) {
+      Ok(ExistsReply::{ exists: native_path_exists(payload.path) })
+    })
+
+    plugin.command_result("removeFile", fn(payload : RemoveFilePayload) {
+      match native_remove_file(payload.path) {
+        Err(error) => Err(error)
+        Ok(removed) => {
+          emit_activity(plugin, "removeFile", path=Some(payload.path))
+          Ok(RemoveFileReply::{ removed, })
+        }
+      }
+    })
+
+    plugin.command_result("readDir", fn(payload : ReadDirPayload) {
+      match native_read_dir(payload.path) {
+        Err(error) => Err(error)
+        Ok(entries) => {
+          emit_activity(plugin, "readDir", path=Some(payload.path))
+          Ok(ReadDirReply::{ entries, })
+        }
+      }
+    })
+  })
+}
+
+///|
+test "fs plugin native helpers can round-trip a file" {
+  let path = "/tmp/moonbit-webview-fs-plugin-roundtrip.txt"
+  let open_result = open_native_file(path, "w+b")
+  let handle = match open_result {
+    Ok(handle) => handle
+    Err(error) => abort(error)
+  }
+
+  match write_native_file(handle, "hello from fs plugin") {
+    Ok(_) => ()
+    Err(error) => abort(error)
+  }
+  match flush_native_file(handle) {
+    Ok(_) => ()
+    Err(error) => abort(error)
+  }
+  match seek_native_file(handle, 0, "set") {
+    Ok(_) => ()
+    Err(error) => abort(error)
+  }
+  let stat = match stat_native_file(handle, Some(path)) {
+    Ok(stat) => stat
+    Err(error) => abort(error)
+  }
+  let reply = match read_native_file(handle, 64) {
+    Ok(reply) => reply
+    Err(error) => abort(error)
+  }
+  assert_eq(stat.size, 20)
+  assert_eq(stat.position, 0)
+  assert_true(stat.exists)
+  assert_true(stat.is_file)
+  assert_false(stat.is_dir)
+  assert_eq(reply.content, "hello from fs plugin")
+  assert_true(reply.eof)
+  match close_native_file(handle) {
+    Ok(_) => ()
+    Err(error) => abort(error)
+  }
+  assert_true(native_path_exists(path))
+  assert_eq(native_remove_file(path), Ok(true))
+  assert_false(native_path_exists(path))
+}
+
+///|
+test "fs plugin native helpers can list a directory" {
+  let file_name = "moonbit-webview-fs-plugin-dir-test.txt"
+  let path = "/tmp/" + file_name
+  let handle = match open_native_file(path, "wb") {
+    Ok(handle) => handle
+    Err(error) => abort(error)
+  }
+  match close_native_file(handle) {
+    Ok(_) => ()
+    Err(error) => abort(error)
+  }
+  let entries = match native_read_dir("/tmp") {
+    Ok(entries) => entries
+    Err(error) => abort(error)
+  }
+  assert_true(entries.contains(file_name))
+  assert_eq(native_remove_file(path), Ok(true))
+}

--- a/plugins/fs/plugin.mbt
+++ b/plugins/fs/plugin.mbt
@@ -423,6 +423,7 @@ fn native_read_dir(path : String) -> Result[Array[String], String] {
 ///
 /// This is useful for UIs that accept portable relative paths but still want to
 /// display or reuse the backend's canonical absolute location.
+
 ///|
 fn native_absolute_path(path : String) -> String {
   @utf8.decode_lossy(absolute_path_ffi(path_to_cstr(path))[:])
@@ -457,6 +458,10 @@ fn emit_activity(
 /// `window.MoonBitPlugins.fs` in JavaScript. Opened handles remember their
 /// resolved absolute path, and `resolvePath` is also exposed as a standalone
 /// plugin command for JS callers that need it before opening files.
+///
+/// This plugin intentionally exposes host filesystem access. Only install it in
+/// webviews that load trusted/local content; do not combine it with untrusted
+/// or remote HTML/JavaScript.
 pub fn plugin() -> @webview.Plugin {
   let handles : Map[Int, NativeFileHandle] = {}
   let paths : Map[Int, String] = {}
@@ -589,11 +594,11 @@ pub fn plugin() -> @webview.Plugin {
         Err(error) => Err(error)
         Ok(file) => {
           let path = paths.get(payload.handle)
-          handles.remove(payload.handle)
-          paths.remove(payload.handle)
           match close_native_file(file) {
             Err(error) => Err(error)
             Ok(_) => {
+              handles.remove(payload.handle)
+              paths.remove(payload.handle)
               emit_activity(plugin, "close", path~, handle=Some(payload.handle))
               Ok(CloseReply::{ closed: true })
             }

--- a/plugins/fs/plugin.mbt
+++ b/plugins/fs/plugin.mbt
@@ -120,6 +120,16 @@ struct ReadDirReply {
 } derive(ToJson, FromJson, Show, Eq)
 
 ///|
+struct ResolvePathPayload {
+  path : String
+} derive(ToJson, FromJson, Show, Eq)
+
+///|
+struct ResolvePathReply {
+  path : String
+} derive(ToJson, FromJson, Show, Eq)
+
+///|
 struct FsActivity {
   operation : String
   path : String?
@@ -199,6 +209,10 @@ extern "C" fn remove_file_ffi(path : Bytes) -> Int = "plugins_fs_remove_file"
 ///|
 #borrow(path)
 extern "C" fn read_dir_ffi(path : Bytes) -> DirectoryEntriesHandle = "plugins_fs_read_dir"
+
+///|
+#borrow(path)
+extern "C" fn absolute_path_ffi(path : Bytes) -> Bytes = "plugins_fs_absolute_path"
 
 ///|
 extern "C" fn entries_handle_is_null(handle : DirectoryEntriesHandle) -> Bool = "moonbit_is_null"
@@ -405,6 +419,11 @@ fn native_read_dir(path : String) -> Result[Array[String], String] {
 }
 
 ///|
+fn native_absolute_path(path : String) -> String {
+  @utf8.decode_lossy(absolute_path_ffi(path_to_cstr(path))[:])
+}
+
+///|
 fn get_open_handle(
   handles : Map[Int, NativeFileHandle],
   handle : Int,
@@ -442,13 +461,14 @@ pub fn plugin() -> @webview.Plugin {
         Err(error) => Err(error)
         Ok(file) => {
           let handle = next_handle
+          let resolved_path = native_absolute_path(payload.path)
           next_handle += 1
           handles.set(handle, file)
-          paths.set(handle, payload.path)
+          paths.set(handle, resolved_path)
           emit_activity(
             plugin,
             "open",
-            path=Some(payload.path),
+            path=Some(resolved_path),
             handle=Some(handle),
           )
           Ok(OpenReply::{ handle, })
@@ -595,12 +615,16 @@ pub fn plugin() -> @webview.Plugin {
         }
       }
     })
+
+    plugin.command_result("resolvePath", fn(payload : ResolvePathPayload) {
+      Ok(ResolvePathReply::{ path: native_absolute_path(payload.path) })
+    })
   })
 }
 
 ///|
 test "fs plugin native helpers can round-trip a file" {
-  let path = "/tmp/moonbit-webview-fs-plugin-roundtrip.txt"
+  let path = "moonbit-webview-fs-plugin-roundtrip.txt"
   let open_result = open_native_file(path, "w+b")
   let handle = match open_result {
     Ok(handle) => handle
@@ -644,9 +668,17 @@ test "fs plugin native helpers can round-trip a file" {
 }
 
 ///|
+test "fs plugin resolves relative paths into absolute paths" {
+  let relative_path = "."
+  let absolute_path = native_absolute_path(relative_path)
+  assert_true(absolute_path != relative_path)
+  assert_true(native_path_exists(absolute_path))
+}
+
+///|
 test "fs plugin native helpers can list a directory" {
   let file_name = "moonbit-webview-fs-plugin-dir-test.txt"
-  let path = "/tmp/" + file_name
+  let path = file_name
   let handle = match open_native_file(path, "wb") {
     Ok(handle) => handle
     Err(error) => abort(error)
@@ -655,7 +687,7 @@ test "fs plugin native helpers can list a directory" {
     Ok(_) => ()
     Err(error) => abort(error)
   }
-  let entries = match native_read_dir("/tmp") {
+  let entries = match native_read_dir(".") {
     Ok(entries) => entries
     Err(error) => abort(error)
   }

--- a/plugins/moon.mod.json
+++ b/plugins/moon.mod.json
@@ -1,0 +1,21 @@
+{
+  "name": "plugins",
+  "version": "0.1.0",
+  "deps": {
+    "justjavac/ffi": "0.1.12",
+    "justjavac/webview": {
+      "path": ".."
+    }
+  },
+  "readme": "README.md",
+  "repository": "https://github.com/justjavac/moonbit-webview/tree/main/plugins",
+  "license": "MIT",
+  "keywords": [
+    "webview",
+    "plugin",
+    "filesystem"
+  ],
+  "description": "Plugins for moonbit-webview examples and applications.",
+  "source": "",
+  "warn-list": ""
+}

--- a/src/binding.mbt
+++ b/src/binding.mbt
@@ -47,6 +47,10 @@ pub extern "C" fn webview_dispatch(
 pub extern "C" fn webview_get_window(webview : Webview_t) -> Int64 = "webview_get_window"
 
 ///|
+/// Returns a stable integer identity for the native webview handle.
+extern "C" fn webview_identity(webview : Webview_t) -> Int64 = "moonbit_webview_identity"
+
+///|
 /// extern void *webview_get_native_handle(webview_t w, webview_native_handle_kind_t kind);
 pub extern "C" fn webview_get_native_handle(
   webview : Webview_t,

--- a/src/pkg.generated.mbti
+++ b/src/pkg.generated.mbti
@@ -125,13 +125,16 @@ type Webview
 pub fn Webview::bind(Self, String, (Bytes, Bytes) -> Unit) -> Unit
 pub fn Webview::destroy(Self) -> Unit
 pub fn Webview::dispatch(Self, () -> Unit) -> Unit
+pub fn[Payload : ToJson] Webview::emit_plugin(Self, String, String, Payload) -> Unit
 pub fn Webview::eval(Self, String) -> Unit
 pub fn Webview::get_handle(Self) -> Webview_t
 pub fn Webview::get_native_handle(Self, NativeHandleKind) -> Int64
 pub fn Webview::get_window(Self) -> Int64
 pub fn Webview::init(Self, String) -> Unit
+pub fn Webview::install_plugin(Self, Plugin) -> Unit
 pub fn Webview::navigate(Self, String) -> Unit
 pub fn Webview::new(debug? : Int) -> Self
+pub fn Webview::plugin_host(Self) -> PluginHost
 pub fn Webview::response(Self, String, Int, String) -> Unit
 pub fn Webview::run(Self) -> Unit
 pub fn Webview::set_html(Self, String) -> Unit

--- a/src/plugin.mbt
+++ b/src/plugin.mbt
@@ -1,5 +1,8 @@
 ///|
-/// A plugin definition that can be installed into a `PluginHost`.
+let default_plugin_hosts : Map[Int64, PluginHost] = {}
+
+///|
+/// A plugin definition that can be installed into a `Webview` or `PluginHost`.
 ///
 /// A plugin is typically exposed from a MoonBit module:
 ///
@@ -14,8 +17,8 @@
 /// ```
 ///
 /// `on_install` runs after the plugin has finished registering commands and
-/// JS helpers on the host. `on_destroy` runs when `PluginHost::destroy()` is
-/// called, before the underlying `CommandBridge` is torn down.
+/// JS helpers on the host. `on_destroy` runs when the owning webview/plugin
+/// host is destroyed, before the underlying `CommandBridge` is torn down.
 struct Plugin {
   name : String
   register : (PluginContext) -> Unit
@@ -24,8 +27,12 @@ struct Plugin {
 }
 
 ///|
-/// Installs MoonBit plugins into a `Webview` and exposes them as JavaScript
-/// APIs through the existing `CommandBridge`.
+/// Advanced plugin host built on top of `CommandBridge`.
+///
+/// Most applications should install plugins through
+/// `webview.install_plugin(...)`, which uses a default `PluginHost` under
+/// `window.MoonBitPlugins`. Construct `PluginHost` directly only when you need
+/// custom JS namespace or bridge names.
 ///
 /// On the JavaScript side this exposes:
 /// - `window[global_name]["@@call"](plugin_name, api_name, payload)`
@@ -43,6 +50,8 @@ struct PluginHost {
   plugins : Map[String, Bool]
   apis : Map[String, Bool]
   destroy_hooks : Map[String, () -> Unit]
+  destroy_hook_name : String
+  default_registry_key : Int64?
 }
 
 ///|
@@ -61,7 +70,8 @@ pub struct PluginEvent {
 } derive(ToJson, FromJson, Show, Eq)
 
 ///|
-/// Builds a plugin value that can later be installed on a `PluginHost`.
+/// Builds a plugin value that can later be installed on a `Webview` or
+/// `PluginHost`.
 pub fn Plugin::new(
   name : String,
   register : (PluginContext) -> Unit,
@@ -73,6 +83,9 @@ pub fn Plugin::new(
 
 ///|
 /// Creates a plugin host backed by a `CommandBridge`.
+///
+/// This is the advanced/manual API. For the default host attached to a webview,
+/// prefer `webview.install_plugin(...)` and `webview.plugin_host()`.
 ///
 /// `global_name` controls the JavaScript namespace used for plugin APIs and
 /// defaults to `window.MoonBitPlugins`.
@@ -86,6 +99,62 @@ pub fn PluginHost::new(
   binding_name? : String = "__moonbit_command",
   event_name? : String = "moonbit:command",
 ) -> PluginHost {
+  make_plugin_host(
+    webview,
+    global_name~,
+    command_global_name~,
+    binding_name~,
+    event_name~,
+  )
+}
+
+///|
+/// Returns the default plugin host attached to this webview.
+///
+/// The host is created lazily and reused by `webview.install_plugin(...)` and
+/// `webview.emit_plugin(...)`.
+pub fn Webview::plugin_host(self : Webview) -> PluginHost {
+  let key = self.identity()
+  match default_plugin_hosts.get(key) {
+    Some(host) => host
+    None => {
+      let host = make_plugin_host(self, default_registry_key=Some(key))
+      default_plugin_hosts.set(key, host)
+      host
+    }
+  }
+}
+
+///|
+/// Installs a plugin into the webview's default plugin host.
+pub fn Webview::install_plugin(self : Webview, plugin : Plugin) -> Unit {
+  self.plugin_host().install(plugin)
+}
+
+///|
+/// Emits a plugin-scoped event from the main program through the webview's
+/// default plugin host.
+pub fn[Payload : ToJson] Webview::emit_plugin(
+  self : Webview,
+  plugin_name : String,
+  event_name : String,
+  payload : Payload,
+) -> Unit {
+  self.plugin_host().emit(plugin_name, event_name, payload)
+}
+
+///|
+fn make_plugin_host(
+  webview : Webview,
+  global_name? : String = "MoonBitPlugins",
+  command_global_name? : String = "MoonBitBridge",
+  binding_name? : String = "__moonbit_command",
+  event_name? : String = "moonbit:command",
+  default_registry_key? : Int64? = None,
+) -> PluginHost {
+  let destroy_hook_name = plugin_host_destroy_hook_name(
+    global_name, binding_name,
+  )
   let host = PluginHost::{
     webview,
     bridge: CommandBridge::new(
@@ -98,7 +167,10 @@ pub fn PluginHost::new(
     plugins: {},
     apis: {},
     destroy_hooks: {},
+    destroy_hook_name,
+    default_registry_key,
   }
+  webview.register_destroy_hook(destroy_hook_name, fn() { host.destroy() })
   host.install_script(make_plugin_host_script(global_name, command_global_name))
   host
 }
@@ -141,6 +213,11 @@ pub fn PluginHost::install(self : PluginHost, plugin : Plugin) -> Unit {
 /// Drops all registered plugin metadata and destroys the underlying
 /// `CommandBridge`.
 pub fn PluginHost::destroy(self : PluginHost) -> Unit {
+  match self.default_registry_key {
+    Some(key) => default_plugin_hosts.remove(key)
+    None => ()
+  }
+  self.webview.unregister_destroy_hook(self.destroy_hook_name)
   for _, hook in self.destroy_hooks {
     hook()
   }
@@ -151,12 +228,13 @@ pub fn PluginHost::destroy(self : PluginHost) -> Unit {
 }
 
 ///|
-/// Runs the underlying webview loop and then tears the plugin host down in the
-/// correct order so destroy hooks run before the native webview is destroyed.
+/// Runs the underlying webview loop.
+///
+/// `PluginHost` cleanup is already attached to the underlying `Webview`
+/// lifecycle, so `webview.run()` and `plugins.run()` are equivalent. Prefer
+/// `webview.run()` in normal application code.
 pub fn PluginHost::run(self : PluginHost) -> Unit {
-  let _ = webview_run(self.webview.get_handle())
-  self.destroy()
-  self.webview.destroy()
+  self.webview.run()
 }
 
 ///|
@@ -171,6 +249,9 @@ pub fn PluginContext::name(self : PluginContext) -> String {
 /// JavaScript receives these events through
 /// `window.MoonBitPlugins[plugin_name]["@@on"](...)` and
 /// `window.MoonBitPlugins[plugin_name]["@@onEvent"](...)`.
+///
+/// For the default host attached to a `Webview`, prefer
+/// `webview.emit_plugin(...)`.
 pub fn[Payload : ToJson] PluginHost::emit(
   self : PluginHost,
   plugin_name : String,
@@ -285,6 +366,14 @@ fn plugin_command_name(plugin_name : String, api_name : String) -> String {
 ///|
 fn plugin_event_command_name() -> String {
   "@@plugin:event"
+}
+
+///|
+fn plugin_host_destroy_hook_name(
+  global_name : String,
+  binding_name : String,
+) -> String {
+  "plugin-host:" + global_name + ":" + binding_name
 }
 
 ///|

--- a/src/stub.c
+++ b/src/stub.c
@@ -76,6 +76,10 @@ int moonbit_webview_unbind(webview_t w, const char *name, void *raw_binding) {
   return result;
 }
 
+int64_t moonbit_webview_identity(webview_t w) {
+  return (int64_t)(intptr_t)w;
+}
+
 moonbit_bytes_t moonbit_webview_copy_cstr(void *raw_cstr) {
   const char *cstr = raw_cstr;
   moonbit_bytes_t bytes;

--- a/src/webview.mbt
+++ b/src/webview.mbt
@@ -39,6 +39,7 @@ pub(all) enum SizeHint {
 struct Webview {
   handle : Webview_t
   bindings : Map[String, BindingHandle]
+  destroy_hooks : Map[String, () -> Unit]
 }
 
 ///|
@@ -48,7 +49,11 @@ struct Webview {
 /// - `debug` - If set to 1, enables debugging mode which provides additional logging.
 pub fn Webview::new(debug? : Int = 0) -> Webview {
   let window : Int64 = 0
-  let webview = Webview::{ handle: webview_create(debug, window), bindings: {} }
+  let webview = Webview::{
+    handle: webview_create(debug, window),
+    bindings: {},
+    destroy_hooks: {},
+  }
   webview
 }
 
@@ -56,6 +61,14 @@ pub fn Webview::new(debug? : Int = 0) -> Webview {
 /// Destroys the webview and closes the window. It is safe to call this
 /// function from another background thread.
 pub fn Webview::destroy(self : Webview) -> Unit {
+  let hooks : Array[() -> Unit] = []
+  for _, hook in self.destroy_hooks {
+    hooks.push(hook)
+  }
+  self.destroy_hooks.clear()
+  for hook in hooks {
+    hook()
+  }
   for name, binding in self.bindings {
     let _ = webview_unbind(self.handle, @ffi.to_cstr(name), binding)
   }
@@ -286,4 +299,28 @@ pub fn Webview::set_size(
 pub fn Webview::run(self : Webview) -> Unit {
   let _ = webview_run(self.handle)
   self.destroy()
+}
+
+///|
+fn Webview::identity(self : Webview) -> Int64 {
+  webview_identity(self.handle)
+}
+
+///|
+fn Webview::register_destroy_hook(
+  self : Webview,
+  hook_name : String,
+  hook : () -> Unit,
+) -> Unit {
+  guard self.destroy_hooks.get(hook_name) is None else {
+    abort(
+      "Webview::register_destroy_hook: hook already registered: " + hook_name,
+    )
+  }
+  self.destroy_hooks.set(hook_name, hook)
+}
+
+///|
+fn Webview::unregister_destroy_hook(self : Webview, hook_name : String) -> Unit {
+  self.destroy_hooks.remove(hook_name)
 }

--- a/test/webview_test.mbt
+++ b/test/webview_test.mbt
@@ -295,13 +295,12 @@ test "Plugin host exposes plugin APIs into JavaScript" {
   let mut seen_event : PluginNoticeEvent? = None
   let mut js_error : String? = None
   let webview = @webview.Webview::new()
-  let plugins = @webview.PluginHost::new(webview)
   let finish = fn() {
     if seen_response is Some(_) && seen_event is Some(_) {
       webview.terminate()
     }
   }
-  plugins.install(
+  webview.install_plugin(
     @webview.Plugin::new("math", fn(plugin) {
       plugin.command("multiply", fn(payload : MultiplyPayload) {
         let reply = MultiplyReply::{ total: payload.left * payload.right }
@@ -392,7 +391,7 @@ test "Plugin host exposes plugin APIs into JavaScript" {
       #| </html>,
     ),
   )
-  plugins.run()
+  webview.run()
   assert_eq(seen_response, Some(expected_response))
   assert_eq(seen_event, Some(expected_event))
   assert_eq(js_error, None)
@@ -433,8 +432,7 @@ test "Plugin lifecycle hooks run on install and destroy" {
   let mut installed_plugin : String? = None
   let mut destroyed_plugin : String? = None
   let webview = @webview.Webview::new()
-  let plugins = @webview.PluginHost::new(webview)
-  plugins.install(
+  webview.install_plugin(
     @webview.Plugin::new(
       "math",
       fn(_plugin) {  },
@@ -444,7 +442,7 @@ test "Plugin lifecycle hooks run on install and destroy" {
   )
   assert_eq(installed_plugin, Some("math"))
   assert_eq(destroyed_plugin, None)
-  plugins.destroy()
+  webview.plugin_host().destroy()
   assert_eq(destroyed_plugin, Some("math"))
 }
 
@@ -453,6 +451,15 @@ test "PluginHost::install allows helper-like plugin names outside the @@ namespa
   let webview = @webview.Webview::new()
   let plugins = @webview.PluginHost::new(webview)
   plugins.install(@webview.Plugin::new("call", fn(_plugin) {  }))
+}
+
+///|
+test "Webview::plugin_host reuses the default host" {
+  let webview = @webview.Webview::new()
+  let first = webview.plugin_host()
+  first.install(@webview.Plugin::new("math", fn(_plugin) {  }))
+  let second = webview.plugin_host()
+  second.install(@webview.Plugin::new("stats", fn(_plugin) {  }))
 }
 
 ///|

--- a/test/webview_test.mbt
+++ b/test/webview_test.mbt
@@ -398,6 +398,92 @@ test "Plugin host exposes plugin APIs into JavaScript" {
 }
 
 ///|
+test "Webview::emit_plugin delivers events to JavaScript listeners" {
+  let expected_event = PluginNoticeEvent::{
+    plugin: "math",
+    name: "computed",
+    payload: PluginNotice::{ message: "MoonBit emitted 42" },
+  }
+  let mut seen_event : PluginNoticeEvent? = None
+  let mut js_error : String? = None
+  let webview = @webview.Webview::new()
+  webview.install_plugin(@webview.Plugin::new("math", fn(_plugin) {  }))
+  webview.bind("reportPluginFailure", fn(id, req) {
+    let request_id = @ffi.from_cstr(id)
+    let message_result : Result[String, String] = decode_single_argument(req)
+    match message_result {
+      Ok(message) => js_error = Some(message)
+      Err(message) =>
+        js_error = Some("Failed to decode plugin failure payload: " + message)
+    }
+    webview.response(request_id, 0, "null")
+    webview.terminate()
+  })
+  webview.bind("reportPluginEvent", fn(id, req) {
+    let request_id = @ffi.from_cstr(id)
+    let event_result : Result[PluginNoticeEvent, String] = decode_single_argument(
+      req,
+    )
+    match event_result {
+      Ok(event) => seen_event = Some(event)
+      Err(message) =>
+        js_error = Some("Failed to decode plugin event payload: " + message)
+    }
+    webview.response(request_id, 0, "null")
+    webview.terminate()
+  })
+  webview.bind("requestNativePluginEvent", fn(id, _req) {
+    let request_id = @ffi.from_cstr(id)
+    webview.emit_plugin("math", "computed", PluginNotice::{
+      message: "MoonBit emitted 42",
+    })
+    webview.response(request_id, 0, "null")
+  })
+  webview.set_html(
+    (
+      #| <html>
+      #|   <body>
+      #|     <script>
+      #|       const reportFailure = (message) =>
+      #|         window.reportPluginFailure(message).catch(() => {});
+      #|       window.addEventListener("error", (event) => {
+      #|         void reportFailure("window error: " + String(event.message));
+      #|       });
+      #|       window.addEventListener("unhandledrejection", (event) => {
+      #|         void reportFailure("unhandled rejection: " + String(event.reason));
+      #|       });
+      #|       window.addEventListener("load", () => {
+      #|         const plugins = window.MoonBitPlugins;
+      #|         const timeoutId = window.setTimeout(() => {
+      #|           void reportFailure("emit_plugin listener timeout");
+      #|         }, 1000);
+      #|         if (!plugins || !plugins.math) {
+      #|           window.clearTimeout(timeoutId);
+      #|           void reportFailure("plugin missing");
+      #|           return;
+      #|         }
+      #|         plugins.math["@@onEvent"]("computed", (event) => {
+      #|           window.clearTimeout(timeoutId);
+      #|           void window.reportPluginEvent(event).catch(() => {});
+      #|         });
+      #|         window.setTimeout(() => {
+      #|           window.requestNativePluginEvent().catch((error) => {
+      #|             window.clearTimeout(timeoutId);
+      #|             void reportFailure("emit_plugin transport error: " + String(error));
+      #|           });
+      #|         }, 0);
+      #|       });
+      #|     </script>
+      #|   </body>
+      #| </html>,
+    ),
+  )
+  webview.run()
+  assert_eq(seen_event, Some(expected_event))
+  assert_eq(js_error, None)
+}
+
+///|
 test "panic CommandBridge::new rejects duplicate binding names" {
   let webview = @webview.Webview::new()
   let _first = @webview.CommandBridge::new(webview)


### PR DESCRIPTION
## Summary
- add a reusable `plugins/fs` module with native filesystem commands, activity events, and native absolute-path resolution
- expose default Webview-level plugin installation helpers for the main application runtime
- add a dedicated `18_plugin_fs` example and evolve it into a usable, compatibility-safe file workbench demo

## Plugin System Diagram
```text
                           MoonBit app side
+---------------------------------------------------------------+
| Webview                                                       |
|                                                               |
|  webview.install_plugin(plugin)                               |
|  webview.emit_plugin(plugin, event, payload)                  |
|  webview.run()                                                |
+-------------------------------+-------------------------------+
                                |
                                v
+---------------------------------------------------------------+
| default PluginHost (lazy, per Webview)                        |
|  - installs plugin namespaces into JS                         |
|  - owns plugin lifecycle hooks                                |
|  - routes plugin events through CommandBridge                 |
+-------------------------------+-------------------------------+
                                |
                                v
+---------------------------------------------------------------+
| CommandBridge                                                 |
|  JS -> MoonBit: plugin:<name>:<api>                           |
|  MoonBit -> JS: @@plugin:event                                |
+-------------------------------+-------------------------------+
                                |
        +-----------------------+-----------------------+
        |                                               |
        v                                               v
+-------------------------------+         +-------------------------------+
| Plugin modules                |         | JavaScript / WebView page     |
|                               |         |                               |
| @webview.Plugin::new("math")  |         | window.MoonBitPlugins         |
| @fs.plugin()                  |         |   .math.sum(payload)          |
|                               |         |   .fs.open/read/write/...     |
| plugin.command(...)           |         |   .fs.resolvePath({ path })   |
| plugin.emit(...)              |         |                               |
| on_install / on_destroy       |         | plugin["@@onEvent"](...)     |
+-------------------------------+         +-------------------------------+
        |                                               ^
        | plugin.command(...)                           |
        +---------------------- JS calls --------------+
        |                                               |
        +------------------- plugin.emit /              |
                            webview.emit_plugin --------+

Example fs plugin flow
----------------------
JS: window.MoonBitPlugins.fs.open({ path, mode })
  -> CommandBridge request
  -> fs plugin native handler
  -> native filesystem call (`fopen` / `read` / `write` / etc.)
  -> CommandResponse returned to JS

JS: window.MoonBitPlugins.fs["@@onEvent"]("activity", listener)
MoonBit: plugin.emit("activity", payload)
  -> PluginHost.emit(...)
  -> CommandBridge sends @@plugin:event
  -> JS plugin listener receives `{ plugin, name, payload }`
```

## What Changed
- added a reusable `plugins` workspace with `plugins/moon.mod.json` and `plugins/README.md`
- implemented the native fs plugin in `plugins/fs/plugin.mbt` with native helpers in `plugins/fs/fs_native.c`
- exposed fs commands for `open`, `read`, `write`, `seek`, `flush`, `close`, `exists`, `readDir`, `removeFile`, `fstat`, and `resolvePath`
- added plugin-scoped `activity` events so JavaScript can observe successful file operations
- added `Webview::install_plugin(...)`, `Webview::plugin_host()`, and `Webview::emit_plugin(...)` for the default plugin host path
- attached plugin cleanup to normal `Webview` shutdown so plugin destroy hooks run during `webview.run()` / `webview.destroy()`
- restored `examples/17_plugin` as the generic math-plugin example
- added `examples/18_plugin_fs` as the dedicated filesystem-plugin example
- simplified the `18_plugin_fs` page implementation so it renders reliably in the embedded webview runtime
- upgraded the `18_plugin_fs` demo into a small file workbench with save/load/inspect/delete/list actions and plugin activity logging
- resolved the `18_plugin_fs` demo path through the native fs plugin so the UI shows platform-specific absolute paths instead of Unix-only defaults or ambiguous relative paths
- updated the root README, examples README, plugin READMEs, and inline fs-plugin comments to document the plugin module workflow and absolute-path behavior
- updated plugin lifecycle/runtime tests to cover the default `Webview` plugin-host path and extended fs native tests for absolute-path resolution

## Validation
- `moon fmt --check` in root, `plugins/`, `examples/`, and `test/`
- `moon check --target native` in root, `plugins/`, `examples/`, `examples/17_plugin/`, `examples/18_plugin_fs/`, and `test/`
- `DYLD_LIBRARY_PATH=../lib moon test --target native` in `plugins/` with `3/3` passed
- `DYLD_LIBRARY_PATH=../lib moon test --target native` in `test/` with `17/17` passed
- `DYLD_LIBRARY_PATH=../lib moon test --target native` in `examples/` with `0` test entries found

## Notes
- the fs plugin now keeps handle paths in resolved absolute form, and `fs.resolvePath({ path })` is available for JS callers that need the native absolute path before opening a file

## The `18_plugin_fs` demo screenshot
<img width="960" height="1014" alt="image" src="https://github.com/user-attachments/assets/9fc347e4-b41c-468e-bec0-8d01568ec777" />
