### PR TITLE
docs: Windows environment setup uses absolute paths and safe quoting

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ export DYLD_LIBRARY_PATH="$(pwd)/.mooncakes/justjavac/webview/lib"
 
 ```bat
 set "MOONWEB_LIB=%CD%\.mooncakes\justjavac\webview\lib"
-set "_CL_=/link /LIBPATH:\"%MOONWEB_LIB%\" webview.lib /DEBUG"
+set _CL_=/link /LIBPATH:"%MOONWEB_LIB%" webview.lib /DEBUG
 set "PATH=%PATH%;%MOONWEB_LIB%"
 ```
 

--- a/README.md
+++ b/README.md
@@ -59,15 +59,17 @@ export DYLD_LIBRARY_PATH="$(pwd)/.mooncakes/justjavac/webview/lib"
 #### Command Prompt
 
 ```bat
-set _CL_=/link /LIBPATH:.mooncakes\justjavac\webview\lib webview.lib /DEBUG
-set PATH=%PATH%;.mooncakes\justjavac\webview\lib
+set "MOONWEB_LIB=%CD%\.mooncakes\justjavac\webview\lib"
+set "_CL_=/link /LIBPATH:\"%MOONWEB_LIB%\" webview.lib /DEBUG"
+set "PATH=%PATH%;%MOONWEB_LIB%"
 ```
 
 #### PowerShell
 
 ```powershell
-$env:_CL_="/link /LIBPATH:.mooncakes\justjavac\webview\lib webview.lib /DEBUG"
-$env:PATH="$env:PATH;.mooncakes\justjavac\webview\lib"
+$libPath = Join-Path -Path (Get-Location) -ChildPath ".mooncakes\justjavac\webview\lib"
+$env:_CL_ = "/link /LIBPATH:`"$libPath`" webview.lib /DEBUG"
+$env:PATH = "$env:PATH;$libPath"
 ```
 
 ### Linux

--- a/README.md
+++ b/README.md
@@ -64,6 +64,8 @@ set "_CL_=/link /LIBPATH:\"%MOONWEB_LIB%\" webview.lib /DEBUG"
 set "PATH=%PATH%;%MOONWEB_LIB%"
 ```
 
+Note: This Windows path handling mirrors the approach used in CI workflow (.github/workflows/ci.yml) to ensure library paths resolve correctly even when the working directory contains spaces.
+
 #### PowerShell
 
 ```powershell


### PR DESCRIPTION
## Summary
- Align Windows environment setup in README with robust path handling by using absolute paths and quoted strings.
- Update CMD and PowerShell examples to prevent issues with spaces and path resolutions.

## Details
- Updated Windows Command Prompt block to use MOONWEB_LIB variable and quoted _CL_ value.
- Updated Windows PowerShell block to resolve lib path dynamically and quote in _CL_ and PATH.

## Rationale
- Prevents misparsing when project path contains spaces and ensures CI workflow consistency.

## How to test
- Open README.md and verify CMD/PowerShell blocks use absolute paths and proper quotes.
- On Windows, run the commands to verify environment variables are set correctly.