### PR TITLE
docs: deprecate no-arg moon install; update docs and CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,10 +33,9 @@ jobs:
         run: |
           moon version --all
 
-      - name: moon install
+      - name: moon update
         run: |
           moon update
-          moon install
 
       - name: moon check
         run: moon check --target native --deny-warn
@@ -133,10 +132,9 @@ jobs:
         run: |
           moon version --all
 
-      - name: moon install
+      - name: moon update
         run: |
           moon update
-          moon install
 
       - name: Setup MSVC
         if: ${{ matrix.os == 'windows-latest' }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,7 +23,7 @@ This document provides concise guidance for agents working in this repository. I
 
 - Dependency management
   - `moon update`
-  - `moon install`
+  - (note: installing without arguments via `moon install` is deprecated; use `moon install <package>` when needed)
   - `moon version --all`
 
 - Quick validation (local)

--- a/README.md
+++ b/README.md
@@ -371,7 +371,8 @@ moon -C examples run <example_name> --target native
 3. **Install dependencies and run examples:**
    ```shell
    moon update
-   moon install
+   # Note: Installing with `moon install` without arguments is deprecated.
+   # If you need a specific tool, use `moon install <package>`.
    moon -C examples run 02_local --target native
    ```
 

--- a/README.md
+++ b/README.md
@@ -372,7 +372,7 @@ moon -C examples run <example_name> --target native
    ```shell
    moon update
    # Note: Installing with `moon install` without arguments is deprecated.
-   # If you need a specific tool, use `moon install <package>`.
+   # If you need a specific package, use `moon install <package>`.
    moon -C examples run 02_local --target native
    ```
 


### PR DESCRIPTION
## Summary
Update docs and CI to reflect deprecation of `moon install` without arguments and remove no-argument install steps from CI.

## What changed
- README.md: clarify installation steps and note deprecation.
- AGENTS.md: document deprecation of no-argument install.
- .github/workflows/ci.yml: simplify install step to rely on update and explicit setup on CI.

## Rationale
Align guidance with Moon's recommended workflow and reduce reliance on deprecated commands in CI.

## Verification
Local formatting/syntax checks pass; CI will run on PR.
