### PR TITLE
feat: adopt expression-based supported-targets and set native as default

### DIFF
--- a/examples/01_run/moon.pkg
+++ b/examples/01_run/moon.pkg
@@ -10,6 +10,5 @@ options(
       "cc-link-flags": "-L../lib -lwebview",
     },
   },
-  "supported-targets": [ "native" ],
   targets: { "main.mbt": [ "native" ] },
 )

--- a/examples/01_tauri_like_helloworld/moon.pkg
+++ b/examples/01_tauri_like_helloworld/moon.pkg
@@ -19,6 +19,5 @@ options(
       "output": "index.mbt",
     },
   ],
-  "supported-targets": [ "native" ],
   targets: { "main.mbt": [ "native" ] },
 )

--- a/examples/02_local/moon.pkg
+++ b/examples/02_local/moon.pkg
@@ -10,6 +10,5 @@ options(
       "cc-link-flags": "-L../lib -lwebview",
     },
   },
-  "supported-targets": [ "native" ],
   targets: { "main.mbt": [ "native" ] },
 )

--- a/examples/03_remote/moon.pkg
+++ b/examples/03_remote/moon.pkg
@@ -10,6 +10,5 @@ options(
       "cc-link-flags": "-L../lib -lwebview",
     },
   },
-  "supported-targets": [ "native" ],
   targets: { "main.mbt": [ "native" ] },
 )

--- a/examples/04_user_agent/moon.pkg
+++ b/examples/04_user_agent/moon.pkg
@@ -10,6 +10,5 @@ options(
       "cc-link-flags": "-L../lib -lwebview",
     },
   },
-  "supported-targets": [ "native" ],
   targets: { "main.mbt": [ "native" ] },
 )

--- a/examples/05_alert/moon.pkg
+++ b/examples/05_alert/moon.pkg
@@ -10,6 +10,5 @@ options(
       "cc-link-flags": "-L../lib -lwebview",
     },
   },
-  "supported-targets": [ "native" ],
   targets: { "main.mbt": [ "native" ] },
 )

--- a/examples/06_onload/moon.pkg
+++ b/examples/06_onload/moon.pkg
@@ -10,6 +10,5 @@ options(
       "cc-link-flags": "-L../lib -lwebview",
     },
   },
-  "supported-targets": [ "native" ],
   targets: { "main.mbt": [ "native" ] },
 )

--- a/examples/07_inject_js/moon.pkg
+++ b/examples/07_inject_js/moon.pkg
@@ -10,6 +10,5 @@ options(
       "cc-link-flags": "-L../lib -lwebview",
     },
   },
-  "supported-targets": [ "native" ],
   targets: { "main.mbt": [ "native" ] },
 )

--- a/examples/08_eval/moon.pkg
+++ b/examples/08_eval/moon.pkg
@@ -10,6 +10,5 @@ options(
       "cc-link-flags": "-L../lib -lwebview",
     },
   },
-  "supported-targets": [ "native" ],
   targets: { "main.mbt": [ "native" ] },
 )

--- a/examples/09_dispatch/moon.pkg
+++ b/examples/09_dispatch/moon.pkg
@@ -10,6 +10,5 @@ options(
       "cc-link-flags": "-L../lib -lwebview",
     },
   },
-  "supported-targets": [ "native" ],
   targets: { "main.mbt": [ "native" ] },
 )

--- a/examples/10_bind/moon.pkg
+++ b/examples/10_bind/moon.pkg
@@ -11,6 +11,5 @@ options(
       "cc-link-flags": "-L../lib -lwebview",
     },
   },
-  "supported-targets": [ "native" ],
   targets: { "main.mbt": [ "native" ] },
 )

--- a/examples/11_multi_window/moon.pkg
+++ b/examples/11_multi_window/moon.pkg
@@ -10,6 +10,5 @@ options(
       "cc-link-flags": "-L../lib -lwebview",
     },
   },
-  "supported-targets": [ "native" ],
   targets: { "main.mbt": [ "native" ] },
 )

--- a/examples/12_embed/moon.pkg
+++ b/examples/12_embed/moon.pkg
@@ -17,6 +17,5 @@ options(
       "output": "hello.mbt",
     },
   ],
-  "supported-targets": [ "native" ],
   targets: { "main.mbt": [ "native" ] },
 )

--- a/examples/13_todo/moon.pkg
+++ b/examples/13_todo/moon.pkg
@@ -17,6 +17,5 @@ options(
       "output": "bundle.mbt",
     },
   ],
-  "supported-targets": [ "native" ],
   targets: { "main.mbt": [ "native" ] },
 )

--- a/examples/14_beforeunload/moon.pkg
+++ b/examples/14_beforeunload/moon.pkg
@@ -10,6 +10,5 @@ options(
       "cc-link-flags": "-L../lib -lwebview",
     },
   },
-  "supported-targets": [ "native" ],
   targets: { "main.mbt": [ "native" ] },
 )

--- a/examples/15_close/moon.pkg
+++ b/examples/15_close/moon.pkg
@@ -10,6 +10,5 @@ options(
       "cc-link-flags": "-L../lib -lwebview",
     },
   },
-  "supported-targets": [ "native" ],
   targets: { "main.mbt": [ "native" ] },
 )

--- a/examples/16_command/moon.pkg
+++ b/examples/16_command/moon.pkg
@@ -18,6 +18,5 @@ options(
       "output": "command.mbt",
     },
   ],
-  "supported-targets": [ "native" ],
   targets: { "main.mbt": [ "native" ] },
 )

--- a/examples/17_plugin/moon.pkg
+++ b/examples/17_plugin/moon.pkg
@@ -18,6 +18,5 @@ options(
       "output": "plugin.mbt",
     },
   ],
-  "supported-targets": [ "native" ],
   targets: { "main.mbt": [ "native" ], "math_plugin.mbt": [ "native" ] },
 )

--- a/examples/18_plugin_fs/moon.pkg
+++ b/examples/18_plugin_fs/moon.pkg
@@ -18,6 +18,5 @@ options(
       "output": "fs.mbt"
     }
   ],
-  "supported-targets": [ "native" ],
   targets: { "main.mbt": [ "native" ] },
 )

--- a/examples/moon.mod.json
+++ b/examples/moon.mod.json
@@ -2,7 +2,7 @@
   "name": "justjavac/webview/examples",
   "version": "0.1.0",
   "deps": {
-    "justjavac/ffi": "0.1.12",
+    "justjavac/ffi": "0.2.0",
     "plugins": {
       "path": "../plugins"
     },
@@ -13,14 +13,10 @@
   "readme": "README.md",
   "repository": "https://github.com/justjavac/moonbit-webview/tree/main/examples",
   "license": "MIT",
-  "keywords": [
-    "webview",
-    "webui",
-    "gui",
-    "web",
-    "desktop-app"
-  ],
+  "keywords": ["webview", "webui", "gui", "web", "desktop-app"],
   "description": "MoonBit bindings for webview, a tiny library for creating web-based desktop GUIs.",
   "source": "",
-  "warn-list": ""
+  "warn-list": "",
+  "supported-targets": "+native",
+  "preferred-target": "native"
 }

--- a/moon.mod.json
+++ b/moon.mod.json
@@ -17,5 +17,7 @@
   ],
   "description": "MoonBit bindings for webview, a tiny library for creating web-based desktop GUIs.",
   "source": "src",
-  "warn-list": ""
+  "warn-list": "",
+  "preferred-target": "native",
+  "supported-targets": "+native"
 }

--- a/plugins/fs/moon.pkg
+++ b/plugins/fs/moon.pkg
@@ -13,6 +13,5 @@ options(
     },
   },
   "native-stub": [ "fs_native.c" ],
-  "supported-targets": [ "native" ],
   targets: { "plugin.mbt": [ "native" ] },
 )

--- a/plugins/moon.mod.json
+++ b/plugins/moon.mod.json
@@ -14,5 +14,6 @@
   "description": "Plugins for moonbit-webview examples and applications.",
   "source": "",
   "warn-list": "",
-  "preferred-target": "native"
+  "preferred-target": "native",
+  "supported-targets": "+native"
 }

--- a/plugins/moon.mod.json
+++ b/plugins/moon.mod.json
@@ -2,7 +2,7 @@
   "name": "plugins",
   "version": "0.1.0",
   "deps": {
-    "justjavac/ffi": "0.1.12",
+    "justjavac/ffi": "0.2.0",
     "justjavac/webview": {
       "path": ".."
     }
@@ -10,12 +10,9 @@
   "readme": "README.md",
   "repository": "https://github.com/justjavac/moonbit-webview/tree/main/plugins",
   "license": "MIT",
-  "keywords": [
-    "webview",
-    "plugin",
-    "filesystem"
-  ],
+  "keywords": ["webview", "plugin", "filesystem"],
   "description": "Plugins for moonbit-webview examples and applications.",
   "source": "",
-  "warn-list": ""
+  "warn-list": "",
+  "preferred-target": "native"
 }

--- a/src/moon.pkg
+++ b/src/moon.pkg
@@ -11,7 +11,7 @@ options(
     },
   },
   "native-stub": [ "stub.c" ],
-  "supported-targets": [ "native" ],
+  "supported-targets": "+native",
   targets: {
     "binding.mbt": [ "native" ],
     "command.mbt": [ "native" ],

--- a/test/moon.mod.json
+++ b/test/moon.mod.json
@@ -2,7 +2,7 @@
   "name": "justjavac/webview/test",
   "version": "0.1.0",
   "deps": {
-    "justjavac/ffi": "0.1.12",
+    "justjavac/ffi": "0.2.0",
     "justjavac/webview": {
       "path": ".."
     }
@@ -10,14 +10,9 @@
   "readme": "README.md",
   "repository": "https://github.com/justjavac/moonbit-webview/tree/main/test",
   "license": "MIT",
-  "keywords": [
-    "webview",
-    "webui",
-    "gui",
-    "web",
-    "desktop-app"
-  ],
+  "keywords": ["webview", "webui", "gui", "web", "desktop-app"],
   "description": "MoonBit bindings for webview, a tiny library for creating web-based desktop GUIs.",
   "source": "",
-  "warn-list": ""
+  "warn-list": "",
+  "preferred-target": "native"
 }

--- a/test/moon.mod.json
+++ b/test/moon.mod.json
@@ -14,5 +14,6 @@
   "description": "MoonBit bindings for webview, a tiny library for creating web-based desktop GUIs.",
   "source": "",
   "warn-list": "",
+  "supported-targets": "+native",
   "preferred-target": "native"
 }

--- a/test/moon.pkg
+++ b/test/moon.pkg
@@ -11,6 +11,5 @@ options(
       "cc-link-flags": "-L../lib -lwebview",
     },
   },
-  "supported-targets": [ "native" ],
   targets: { "webview_test": [ "native" ] },
 )


### PR DESCRIPTION
This PR migrates all legacy supported-targets array syntax to expression-based forms (e.g., +native), and sets native as the default target via preferred-target where applicable. It removes outdated array syntax to align with MoonBit 2026 updates and improves tooling consistency across modules and examples.