### PR TITLE
fix(examples): add supported-targets to all example packages

### DIFF
--- a/examples/01_run/moon.pkg
+++ b/examples/01_run/moon.pkg
@@ -11,4 +11,5 @@ options(
     },
   },
   targets: { "main.mbt": [ "native" ] },
+  "supported-targets": "native",
 )

--- a/examples/01_tauri_like_helloworld/moon.pkg
+++ b/examples/01_tauri_like_helloworld/moon.pkg
@@ -20,4 +20,5 @@ options(
     },
   ],
   targets: { "main.mbt": [ "native" ] },
+  "supported-targets": "native",
 )

--- a/examples/02_local/moon.pkg
+++ b/examples/02_local/moon.pkg
@@ -11,4 +11,5 @@ options(
     },
   },
   targets: { "main.mbt": [ "native" ] },
+  "supported-targets": "native",
 )

--- a/examples/03_remote/moon.pkg
+++ b/examples/03_remote/moon.pkg
@@ -11,5 +11,5 @@ options(
     },
   },
   targets: { "main.mbt": [ "native" ] },
-  "supported-targets": "native",
+  "supported-targets": "+native",
 )

--- a/examples/03_remote/moon.pkg
+++ b/examples/03_remote/moon.pkg
@@ -11,4 +11,5 @@ options(
     },
   },
   targets: { "main.mbt": [ "native" ] },
+  "supported-targets": "native",
 )

--- a/examples/04_user_agent/moon.pkg
+++ b/examples/04_user_agent/moon.pkg
@@ -11,5 +11,5 @@ options(
     },
   },
   targets: { "main.mbt": [ "native" ] },
-  "supported-targets": "native",
+  "supported-targets": "+native",
 )

--- a/examples/04_user_agent/moon.pkg
+++ b/examples/04_user_agent/moon.pkg
@@ -11,4 +11,5 @@ options(
     },
   },
   targets: { "main.mbt": [ "native" ] },
+  "supported-targets": "native",
 )

--- a/examples/05_alert/moon.pkg
+++ b/examples/05_alert/moon.pkg
@@ -11,4 +11,5 @@ options(
     },
   },
   targets: { "main.mbt": [ "native" ] },
+  "supported-targets": "native",
 )

--- a/examples/06_onload/moon.pkg
+++ b/examples/06_onload/moon.pkg
@@ -11,5 +11,5 @@ options(
     },
   },
   targets: { "main.mbt": [ "native" ] },
-  "supported-targets": "native",
+  "supported-targets": "+native",
 )

--- a/examples/06_onload/moon.pkg
+++ b/examples/06_onload/moon.pkg
@@ -11,4 +11,5 @@ options(
     },
   },
   targets: { "main.mbt": [ "native" ] },
+  "supported-targets": "native",
 )

--- a/examples/07_inject_js/moon.pkg
+++ b/examples/07_inject_js/moon.pkg
@@ -11,4 +11,5 @@ options(
     },
   },
   targets: { "main.mbt": [ "native" ] },
+  "supported-targets": "native",
 )

--- a/examples/08_eval/moon.pkg
+++ b/examples/08_eval/moon.pkg
@@ -11,5 +11,5 @@ options(
     },
   },
   targets: { "main.mbt": [ "native" ] },
-  "supported-targets": "native",
+  "supported-targets": "+native",
 )

--- a/examples/08_eval/moon.pkg
+++ b/examples/08_eval/moon.pkg
@@ -11,4 +11,5 @@ options(
     },
   },
   targets: { "main.mbt": [ "native" ] },
+  "supported-targets": "native",
 )

--- a/examples/09_dispatch/moon.pkg
+++ b/examples/09_dispatch/moon.pkg
@@ -11,4 +11,5 @@ options(
     },
   },
   targets: { "main.mbt": [ "native" ] },
+  "supported-targets": "native",
 )

--- a/examples/10_bind/moon.pkg
+++ b/examples/10_bind/moon.pkg
@@ -12,4 +12,5 @@ options(
     },
   },
   targets: { "main.mbt": [ "native" ] },
+  "supported-targets": "native",
 )

--- a/examples/10_bind/moon.pkg
+++ b/examples/10_bind/moon.pkg
@@ -12,5 +12,5 @@ options(
     },
   },
   targets: { "main.mbt": [ "native" ] },
-  "supported-targets": "native",
+  "supported-targets": "+native",
 )

--- a/examples/11_multi_window/moon.pkg
+++ b/examples/11_multi_window/moon.pkg
@@ -11,4 +11,5 @@ options(
     },
   },
   targets: { "main.mbt": [ "native" ] },
+  "supported-targets": "native",
 )

--- a/examples/12_embed/moon.pkg
+++ b/examples/12_embed/moon.pkg
@@ -18,4 +18,5 @@ options(
     },
   ],
   targets: { "main.mbt": [ "native" ] },
+  "supported-targets": "native",
 )

--- a/examples/12_embed/moon.pkg
+++ b/examples/12_embed/moon.pkg
@@ -18,5 +18,5 @@ options(
     },
   ],
   targets: { "main.mbt": [ "native" ] },
-  "supported-targets": "native",
+  "supported-targets": "+native",
 )

--- a/examples/13_todo/moon.pkg
+++ b/examples/13_todo/moon.pkg
@@ -18,4 +18,5 @@ options(
     },
   ],
   targets: { "main.mbt": [ "native" ] },
+  "supported-targets": "native",
 )

--- a/examples/14_beforeunload/moon.pkg
+++ b/examples/14_beforeunload/moon.pkg
@@ -11,4 +11,5 @@ options(
     },
   },
   targets: { "main.mbt": [ "native" ] },
+  "supported-targets": "native",
 )

--- a/examples/15_close/moon.pkg
+++ b/examples/15_close/moon.pkg
@@ -11,5 +11,5 @@ options(
     },
   },
   targets: { "main.mbt": [ "native" ] },
-  "supported-targets": "native",
+  "supported-targets": "+native",
 )

--- a/examples/15_close/moon.pkg
+++ b/examples/15_close/moon.pkg
@@ -11,4 +11,5 @@ options(
     },
   },
   targets: { "main.mbt": [ "native" ] },
+  "supported-targets": "native",
 )

--- a/examples/16_command/moon.pkg
+++ b/examples/16_command/moon.pkg
@@ -19,5 +19,5 @@ options(
     },
   ],
   targets: { "main.mbt": [ "native" ] },
-  "supported-targets": "native",
+  "supported-targets": "+native",
 )

--- a/examples/16_command/moon.pkg
+++ b/examples/16_command/moon.pkg
@@ -19,4 +19,5 @@ options(
     },
   ],
   targets: { "main.mbt": [ "native" ] },
+  "supported-targets": "native",
 )

--- a/examples/17_plugin/moon.pkg
+++ b/examples/17_plugin/moon.pkg
@@ -19,4 +19,5 @@ options(
     },
   ],
   targets: { "main.mbt": [ "native" ], "math_plugin.mbt": [ "native" ] },
+  "supported-targets": "native",
 )

--- a/examples/17_plugin/moon.pkg
+++ b/examples/17_plugin/moon.pkg
@@ -19,5 +19,5 @@ options(
     },
   ],
   targets: { "main.mbt": [ "native" ], "math_plugin.mbt": [ "native" ] },
-  "supported-targets": "native",
+  "supported-targets": "+native",
 )

--- a/examples/18_plugin_fs/moon.pkg
+++ b/examples/18_plugin_fs/moon.pkg
@@ -19,5 +19,5 @@ options(
     }
   ],
   targets: { "main.mbt": [ "native" ] },
-  "supported-targets": "native",
+  "supported-targets": "+native",
 )

--- a/examples/18_plugin_fs/moon.pkg
+++ b/examples/18_plugin_fs/moon.pkg
@@ -19,4 +19,5 @@ options(
     }
   ],
   targets: { "main.mbt": [ "native" ] },
+  "supported-targets": "native",
 )


### PR DESCRIPTION
## Summary
- Add explicit `supported-targets: native` declaration to all 19 example packages
- Fixes warnings when building examples with native target that depend on `justjavac/webview` which declares `supported-targets`

The warnings indicated that example packages should declare their supported targets explicitly to match the dependency.